### PR TITLE
insert columns in sorted order

### DIFF
--- a/src/lineup/ARankingView.ts
+++ b/src/lineup/ARankingView.ts
@@ -279,7 +279,7 @@ export abstract class ARankingView extends AView {
     this.fire(AView.EVENT_UPDATE_ENTRY_POINT, namedSet);
   }
 
-  private addColumn(colDesc: any, data: Promise<IScoreRow<any>[]>, id = -1, position): { col: Column, loaded: Promise<Column> } {
+  private addColumn(colDesc: any, data: Promise<IScoreRow<any>[]>, id = -1, position?: number): { col: Column, loaded: Promise<Column> } {
     const ranking = this.provider.getLastRanking();
 
     //mark as lazy loaded

--- a/src/lineup/ARankingView.ts
+++ b/src/lineup/ARankingView.ts
@@ -292,13 +292,12 @@ export abstract class ARankingView extends AView {
 
     this.provider.pushDesc(colDesc);
 
-    let col: Column;
+    const col: Column = this.provider.create(colDesc);
     if(lastIndex === -1) {
       // insert the column at the end of the ranking
-      col = this.provider.push(ranking, colDesc);
+      ranking.push(col);
     } else {
       // insert the column after the last occurrence of the current selected ID
-      col = this.provider.create(colDesc);
       const prevColumn = ranking.flatColumns[lastIndex];
       prevColumn.insertAfterMe(col);
     }

--- a/src/lineup/ARankingView.ts
+++ b/src/lineup/ARankingView.ts
@@ -279,7 +279,7 @@ export abstract class ARankingView extends AView {
     this.fire(AView.EVENT_UPDATE_ENTRY_POINT, namedSet);
   }
 
-  private addColumn(colDesc: any, data: Promise<IScoreRow<any>[]>, id = -1, position = -1): { col: Column, loaded: Promise<Column> } {
+  private addColumn(colDesc: any, data: Promise<IScoreRow<any>[]>, id = -1, position): { col: Column, loaded: Promise<Column> } {
     const ranking = this.provider.getLastRanking();
 
     //mark as lazy loaded
@@ -290,8 +290,7 @@ export abstract class ARankingView extends AView {
     this.provider.pushDesc(colDesc);
 
     const col: Column = this.provider.create(colDesc);
-    if(position === -1) {
-      // insert the column at the end of the ranking
+    if(position === undefined || position === null) {
       ranking.push(col);
     } else {
       ranking.insert(col, position);

--- a/src/lineup/ARankingView.ts
+++ b/src/lineup/ARankingView.ts
@@ -287,8 +287,21 @@ export abstract class ARankingView extends AView {
     colDesc.color = this.colors.getColumnColor(id);
     const accessor = createAccessor(colDesc);
 
+    // find last index of the current selected ID
+    const lastIndex = ranking.flatColumns.map((col) => (<any>col.desc).selectedId).lastIndexOf(id);
+
     this.provider.pushDesc(colDesc);
-    const col = this.provider.push(ranking, colDesc);
+
+    let col: Column;
+    if(lastIndex === -1) {
+      // insert the column at the end of the ranking
+      col = this.provider.push(ranking, colDesc);
+    } else {
+      // insert the column after the last occurrence of the current selected ID
+      col = this.provider.create(colDesc);
+      const prevColumn = ranking.flatColumns[lastIndex];
+      prevColumn.insertAfterMe(col);
+    }
 
     // error handling
     data

--- a/src/lineup/ARankingView.ts
+++ b/src/lineup/ARankingView.ts
@@ -294,9 +294,7 @@ export abstract class ARankingView extends AView {
       // insert the column at the end of the ranking
       ranking.push(col);
     } else {
-      // insert the column after the last occurrence of the current selected ID
-      const prevColumn = ranking.flatColumns[position];
-      prevColumn.insertAfterMe(col);
+      ranking.insert(col, position);
     }
 
     // error handling

--- a/src/lineup/ARankingView.ts
+++ b/src/lineup/ARankingView.ts
@@ -215,7 +215,7 @@ export abstract class ARankingView extends AView {
       selection: this.selection,
       freeColor: (id: number) => this.colors.freeColumnColor(id),
       add: (columns: ISelectionColumn[]) => this.withoutTracking(() => {
-        columns.forEach((col) => this.addColumn(col.desc, col.data, col.id));
+        columns.forEach((col) => this.addColumn(col.desc, col.data, col.id, col.position));
       }),
       remove: (columns: Column[]) => this.withoutTracking(() => {
         columns.forEach((c) => c.removeMe());
@@ -279,7 +279,7 @@ export abstract class ARankingView extends AView {
     this.fire(AView.EVENT_UPDATE_ENTRY_POINT, namedSet);
   }
 
-  private addColumn(colDesc: any, data: Promise<IScoreRow<any>[]>, id = -1): { col: Column, loaded: Promise<Column> } {
+  private addColumn(colDesc: any, data: Promise<IScoreRow<any>[]>, id = -1, position = -1): { col: Column, loaded: Promise<Column> } {
     const ranking = this.provider.getLastRanking();
 
     //mark as lazy loaded
@@ -287,18 +287,15 @@ export abstract class ARankingView extends AView {
     colDesc.color = this.colors.getColumnColor(id);
     const accessor = createAccessor(colDesc);
 
-    // find last index of the current selected ID
-    const lastIndex = ranking.flatColumns.map((col) => (<any>col.desc).selectedId).lastIndexOf(id);
-
     this.provider.pushDesc(colDesc);
 
     const col: Column = this.provider.create(colDesc);
-    if(lastIndex === -1) {
+    if(position === -1) {
       // insert the column at the end of the ranking
       ranking.push(col);
     } else {
       // insert the column after the last occurrence of the current selected ID
-      const prevColumn = ranking.flatColumns[lastIndex];
+      const prevColumn = ranking.flatColumns[position];
       prevColumn.insertAfterMe(col);
     }
 

--- a/src/lineup/selection/ISelectionAdapter.ts
+++ b/src/lineup/selection/ISelectionAdapter.ts
@@ -6,6 +6,7 @@ export interface ISelectionColumn {
   readonly id: number;
   readonly desc: IColumnDesc;
   readonly data: Promise<IScoreRow<any>[]>;
+  readonly position?: number;
 }
 
 /**

--- a/src/lineup/selection/internal/ABaseSelectionAdapter.ts
+++ b/src/lineup/selection/internal/ABaseSelectionAdapter.ts
@@ -14,8 +14,16 @@ export function patchDesc(desc: IAdditionalColumnDesc, selectedId: number) {
 export abstract class ABaseSelectionAdapter {
 
   protected addDynamicColumns(context: IContext, _ids: number[], ids: string[]): void {
-    Promise.all(_ids.map((_id, i) => this.createColumnsFor(context, _id, ids[i], i))).then((columns) => {
-      context.add([].concat(...columns));
+    Promise.all(_ids.map((_id, i) => this.createColumnsFor(context, _id, ids[i]))).then((columns) => {
+      // sort new columns to insert them in the correct order
+      const flattenedColumns = [].concat(...columns);
+      flattenedColumns.sort((a, b) => {
+        if(a.position === b.position) { // equal position, sort latter element of original array to lower position in sorted array
+          return 1;
+        }
+        return b.position - a.position; // sort descendingly by default
+      });
+      context.add(flattenedColumns);
     });
   }
 
@@ -80,7 +88,7 @@ export abstract class ABaseSelectionAdapter {
     }
   }
 
-  protected abstract createColumnsFor(context: IContext, _id: number, id: string, offset: number): PromiseLike<ISelectionColumn[]>;
+  protected abstract createColumnsFor(context: IContext, _id: number, id: string): PromiseLike<ISelectionColumn[]>;
 }
 
 export default ABaseSelectionAdapter;

--- a/src/lineup/selection/internal/ABaseSelectionAdapter.ts
+++ b/src/lineup/selection/internal/ABaseSelectionAdapter.ts
@@ -13,21 +13,21 @@ export function patchDesc(desc: IAdditionalColumnDesc, selectedId: number) {
 
 export abstract class ABaseSelectionAdapter {
 
-  protected addDynamicColumns(context: IContext, _ids: number[], ids: string[]): void {
-    Promise.all(_ids.map((_id, i) => this.createColumnsFor(context, _id, ids[i]))).then((columns) => {
+  protected addDynamicColumns(context: IContext, _ids: number[], ids: string[]) {
+    return Promise.all(_ids.map((_id, i) => this.createColumnsFor(context, _id, ids[i]))).then((columns) => {
       // sort new columns to insert them in the correct order
-      const flattenedColumns = [].concat(...columns);
-      flattenedColumns.sort((a, b) => {
-        if(a.position === b.position) { // equal position, sort latter element of original array to lower position in sorted array
-          return 1;
+      const flattenedColumns = [].concat(...columns).map((d, i) => ({d, i}));
+      flattenedColumns.sort(({d: a, i: ai}, {d: b, i: bi}) => {
+        if (a.position === b.position) { // equal position, sort latter element of original array to lower position in sorted array
+          return bi - ai; // the latter in the array the better
         }
-        return b.position - a.position; // sort descendingly by default
+        return b.position - a.position; // sort descending by default
       });
-      context.add(flattenedColumns);
+      context.add(flattenedColumns.map((d) => d.d));
     });
   }
 
-  private removeDynamicColumns(context: IContext, _ids: number[]): void {
+  protected removeDynamicColumns(context: IContext, _ids: number[]): void {
     const columns = context.columns;
     context.remove([].concat(..._ids.map((_id) => {
       context.freeColor(_id);
@@ -35,42 +35,35 @@ export abstract class ABaseSelectionAdapter {
     })));
   }
 
-  private selectionChangedTimer = -1;
-  private parameterChangedTimer = -1;
+  private waitingForSelection = false;
+  private waitingForParameter = false;
 
-  selectionChanged(waitForIt: PromiseLike<any>|null, context: () => IContext) {
-    // wait for the promise and then a debounce logic
-    resolveImmediately(waitForIt).then(() => {
-      if (this.selectionChangedTimer >= 0) {
-        clearTimeout(this.selectionChangedTimer);
-        this.selectionChangedTimer = -1;
-      }
-      this.selectionChangedTimer = <any>setTimeout(() => {
-        this.selectionChangedImpl(context());
-      }, 100);
+  selectionChanged(waitForIt: PromiseLike<any> | null, context: () => IContext) {
+    if (this.waitingForSelection) {
+      return;
+    }
+    this.waitingForSelection = true;
+    resolveImmediately(waitForIt).then(() => this.selectionChangedImpl(context())).then(() => {
+      this.waitingForSelection = false;
     });
   }
 
-  parameterChanged(waitForIt: PromiseLike<any>|null, context: () => IContext) {
-    resolveImmediately(waitForIt).then(() => {
-      if (this.parameterChangedTimer >= 0) {
-        clearTimeout(this.parameterChangedTimer);
-        this.parameterChangedTimer = -1;
-      }
-      this.parameterChangedTimer = <any>setTimeout(() => {
-        this.parameterChangedImpl(context());
-      }, 100);
+  parameterChanged(waitForIt: PromiseLike<any> | null, context: () => IContext) {
+    if (this.waitingForSelection || this.waitingForParameter) {
+      return;
+    }
+    this.waitingForParameter = true;
+    resolveImmediately(waitForIt).then(() => this.parameterChangedImpl(context())).then(() => {
+      this.waitingForParameter = false;
     });
   }
 
-  protected abstract parameterChangedImpl(context: IContext): void;
+  protected abstract parameterChangedImpl(context: IContext): PromiseLike<any>;
 
   protected selectionChangedImpl(context: IContext) {
     const selectedIds = context.selection.range.dim(0).asList();
-    const usedCols = context.columns.filter((d) => (<IAdditionalColumnDesc>d.desc).selectedId !== -1);
-    const lineupColIds = usedCols
-      .map((d) => (<IAdditionalColumnDesc>d.desc).selectedId)
-      .filter((d) => d !== undefined);
+    const usedCols = context.columns.filter((d) => (<IAdditionalColumnDesc>d.desc).selectedId !== -1 && (<IAdditionalColumnDesc>d.desc).selectedId !== undefined);
+    const lineupColIds = usedCols.map((d) => (<IAdditionalColumnDesc>d.desc).selectedId);
 
     // compute the difference
     const diffAdded = array_diff(selectedIds, lineupColIds);
@@ -82,10 +75,11 @@ export abstract class ABaseSelectionAdapter {
       this.removeDynamicColumns(context, diffRemoved);
     }
     // add new columns to the end
-    if (diffAdded.length > 0) {
-      //console.log('add columns', diffAdded);
-      context.selection.idtype.unmap(diffAdded).then((names) => this.addDynamicColumns(context, diffAdded, names));
+    if (diffAdded.length <= 0) {
+      return null;
     }
+    //console.log('add columns', diffAdded);
+    return context.selection.idtype.unmap(diffAdded).then((names) => this.addDynamicColumns(context, diffAdded, names));
   }
 
   protected abstract createColumnsFor(context: IContext, _id: number, id: string): PromiseLike<ISelectionColumn[]>;

--- a/src/lineup/selection/internal/ABaseSelectionAdapter.ts
+++ b/src/lineup/selection/internal/ABaseSelectionAdapter.ts
@@ -14,7 +14,7 @@ export function patchDesc(desc: IAdditionalColumnDesc, selectedId: number) {
 export abstract class ABaseSelectionAdapter {
 
   protected addDynamicColumns(context: IContext, _ids: number[], ids: string[]): void {
-    Promise.all(_ids.map((_id, i) => this.createColumnsFor(context, _id, ids[i]))).then((columns) => {
+    Promise.all(_ids.map((_id, i) => this.createColumnsFor(context, _id, ids[i], i))).then((columns) => {
       context.add([].concat(...columns));
     });
   }
@@ -80,7 +80,7 @@ export abstract class ABaseSelectionAdapter {
     }
   }
 
-  protected abstract createColumnsFor(context: IContext, _id: number, id: string): PromiseLike<ISelectionColumn[]>;
+  protected abstract createColumnsFor(context: IContext, _id: number, id: string, offset: number): PromiseLike<ISelectionColumn[]>;
 }
 
 export default ABaseSelectionAdapter;

--- a/src/lineup/selection/internal/MultiSelectionAdapter.ts
+++ b/src/lineup/selection/internal/MultiSelectionAdapter.ts
@@ -101,6 +101,6 @@ export default class MultiSelectionAdapter extends ABaseSelectionAdapter impleme
 
     // find last index of current ID + consider how many columns have been added so far (offset), since context.columns is not yet updated
     const lastIndex = ids.lastIndexOf(id);
-    return  lastIndex === -1? lastIndex : lastIndex + offset;
+    return  lastIndex === -1? lastIndex : lastIndex + offset + 1;
   }
 }

--- a/src/lineup/selection/internal/MultiSelectionAdapter.ts
+++ b/src/lineup/selection/internal/MultiSelectionAdapter.ts
@@ -22,7 +22,7 @@ export interface IMultiSelectionAdapter {
    * @param {string[]} subTypes the currently selected sub types
    * @returns {Promise<IAdditionalColumnDesc[]>} the created descriptions
    */
-  createDescs(_id: number, id: string, subTypes: string[]): Promise<IAdditionalColumnDesc[]>|IAdditionalColumnDesc[];
+  createDescs(_id: number, id: string, subTypes: string[]): Promise<IAdditionalColumnDesc[]> | IAdditionalColumnDesc[];
 
   /**
    * load the data for the given selection and the selected descriptions
@@ -42,7 +42,7 @@ export default class MultiSelectionAdapter extends ABaseSelectionAdapter impleme
   protected parameterChangedImpl(context: IContext) {
     const selectedIds = context.selection.range.dim(0).asList();
     this.removePartialDynamicColumns(context, selectedIds);
-    context.selection.idtype.unmap(selectedIds).then((names) => this.addDynamicColumns(context, selectedIds, names));
+    return context.selection.idtype.unmap(selectedIds).then((names) => this.addDynamicColumns(context, selectedIds, names));
   }
 
   protected createColumnsFor(context: IContext, _id: number, id: string) {
@@ -101,6 +101,6 @@ export default class MultiSelectionAdapter extends ABaseSelectionAdapter impleme
 
     // find last index of current ID + consider how many columns have been added so far (offset), since context.columns is not yet updated
     const lastIndex = ids.lastIndexOf(id);
-    return  lastIndex === -1? context.columns.length : lastIndex + 1;
+    return lastIndex === -1 ? context.columns.length : lastIndex + 1;
   }
 }

--- a/src/lineup/selection/internal/MultiSelectionAdapter.ts
+++ b/src/lineup/selection/internal/MultiSelectionAdapter.ts
@@ -45,7 +45,7 @@ export default class MultiSelectionAdapter extends ABaseSelectionAdapter impleme
     context.selection.idtype.unmap(selectedIds).then((names) => this.addDynamicColumns(context, selectedIds, names));
   }
 
-  protected createColumnsFor(context: IContext, _id: number, id: string, offset: number) {
+  protected createColumnsFor(context: IContext, _id: number, id: string) {
     const selectedSubTypes = this.adapter.getSelectedSubTypes();
     return resolveImmediately(this.adapter.createDescs(_id, id, selectedSubTypes)).then((descs) => {
       if (descs.length <= 0) {
@@ -68,7 +68,7 @@ export default class MultiSelectionAdapter extends ABaseSelectionAdapter impleme
       const columnsToBeAdded = descs.filter((desc) => addedParameters.has(`${_id}_${desc.selectedSubtype}`));
       const data = this.adapter.loadData(_id, id, columnsToBeAdded);
 
-      const position = this.computePositionToInsert(context, _id, offset);
+      const position = this.computePositionToInsert(context, _id);
 
       return columnsToBeAdded.map((desc, i) => ({desc, data: data[i], id: _id, position}));
     });
@@ -96,11 +96,11 @@ export default class MultiSelectionAdapter extends ABaseSelectionAdapter impleme
     })));
   }
 
-  private computePositionToInsert(context: IContext, id: number, offset: number) {
+  private computePositionToInsert(context: IContext, id: number) {
     const ids = context.columns.map((col) => (<IAdditionalColumnDesc>col.desc).selectedId);
 
     // find last index of current ID + consider how many columns have been added so far (offset), since context.columns is not yet updated
     const lastIndex = ids.lastIndexOf(id);
-    return  lastIndex === -1? lastIndex : lastIndex + offset + 1;
+    return  lastIndex === -1? context.columns.length : lastIndex + 1;
   }
 }

--- a/src/lineup/selection/internal/SingleSelectionAdapter.ts
+++ b/src/lineup/selection/internal/SingleSelectionAdapter.ts
@@ -14,7 +14,7 @@ export interface ISingleSelectionAdapter {
    * @param {string} id the associated name of the unique id
    * @returns {Promise<IAdditionalColumnDesc>} the created description
    */
-  createDesc(_id: number, id: string): Promise<IAdditionalColumnDesc>|IAdditionalColumnDesc;
+  createDesc(_id: number, id: string): Promise<IAdditionalColumnDesc> | IAdditionalColumnDesc;
 
   /**
    * loads the score data for the given selection
@@ -29,11 +29,29 @@ export default class SingleSelectionAdapter extends ABaseSelectionAdapter implem
   constructor(private readonly adapter: ISingleSelectionAdapter) {
     super();
   }
-  protected parameterChangedImpl() {
-    // dummy
+
+  protected parameterChangedImpl(context: IContext) {
+    // remove all and start again
+    const selectedIds = context.selection.range.dim(0).asList();
+    const usedCols = context.columns.filter((d) => (<IAdditionalColumnDesc>d.desc).selectedId !== -1 && (<IAdditionalColumnDesc>d.desc).selectedId !== undefined);
+    const lineupColIds = usedCols.map((d) => (<IAdditionalColumnDesc>d.desc).selectedId);
+
+    // remove deselected columns
+    if (lineupColIds.length > 0) {
+      this.removeDynamicColumns(context, lineupColIds);
+    }
+    // add new columns to the end
+    if (selectedIds.length <= 0) {
+      return null;
+    }
+    return context.selection.idtype.unmap(selectedIds).then((names) => this.addDynamicColumns(context, selectedIds, names));
   }
 
   protected createColumnsFor(context: IContext, _id: number, id: string) {
-    return resolveImmediately(this.adapter.createDesc(_id, id)).then((desc) => [{desc: patchDesc(desc, _id), data: this.adapter.loadData(_id, id), id: _id}]);
+    return resolveImmediately(this.adapter.createDesc(_id, id)).then((desc) => [{
+      desc: patchDesc(desc, _id),
+      data: this.adapter.loadData(_id, id),
+      id: _id
+    }]);
   }
 }

--- a/tdp_core/__init__.py
+++ b/tdp_core/__init__.py
@@ -25,11 +25,6 @@ def phovea(registry):
                   {
                       'namespace': '/api/tdp/storage'
                   })
-
-  registry.append('namespace', 'processing', 'tdp_core.processing',
-                  {
-                      'namespace': '/api/tdp/processing'
-                  })
   registry.append('mapping_provider', 'tdp_core', 'tdp_core.mapping_table')
   # generator-phovea:end
   pass


### PR DESCRIPTION
Add columns to a ranking in a sorted order. If there are already columns with the selected ID in the ranking, the new column will be inserted between the last occurrence of the selected ID and before the next ID
If the selected ID was not found the new column is inserted at the end of the ranking