### PR TITLE
change default alias for generated count to 'd'

### DIFF
--- a/tdp_core/db.py
+++ b/tdp_core/db.py
@@ -332,7 +332,7 @@ def _get_count(database, view_name, args):
   if 'count' in view.queries:
     count_query = view.queries['count']
   elif view.table:
-    count_query = 'SELECT count(*) as count FROM {table} t {{where}}'.format(table=view.table)
+    count_query = 'SELECT count(*) as count FROM {table} d {{where}}'.format(table=view.table)
   else:
     count_query = None
     abort(500, 'invalid view configuration, missing count query and cannot derive it')


### PR DESCRIPTION
since convention
 * `d` for the data to be filtered
 * `g` for the gene join
 * `s` for the sample join

i.e. a count query on genes needs to use `d` since `d` will be used for filtering