### PR TITLE
fix that the previous value === the current value when the filter is …

### DIFF
--- a/src/form/internal/FormMap.ts
+++ b/src/form/internal/FormMap.ts
@@ -413,7 +413,10 @@ export default class FormMap extends AFormElement<IFormMapDesc> {
    */
   get value() {
     // just rows with a valid key and value
-    return this.rows.filter((d) => d.key && d.value !== null);
+    const validRows = this.rows.filter((d) => d.key && d.value !== null);
+
+    // create copies from each row, such that the previous values don't reference to this.value
+    return validRows.map((row) => Object.assign({}, row));
   }
 
   hasValue() {


### PR DESCRIPTION
…applied twice for the same key (e.g. gender first filtered for female and then male and female)