### PR TITLE
fix #60 security checks for views client and server side

### DIFF
--- a/src/views/interfaces.ts
+++ b/src/views/interfaces.ts
@@ -4,6 +4,7 @@ import ProvenanceGraph from 'phovea_core/src/provenance/ProvenanceGraph';
 import {IObjectRef} from 'phovea_core/src/provenance';
 import {IEventHandler} from 'phovea_core/src/event';
 import Range from 'phovea_core/src/range/Range';
+import {IUser} from 'phovea_core/src/security';
 
 /**
  * mode of the view depending on the view state
@@ -34,6 +35,11 @@ export interface IViewPluginDesc extends IPluginDesc {
    * @returns {Promise<string>}
    */
   preview?(): Promise<string>;
+
+  /**
+   * optional security check to show only certain views
+   */
+  security?: string|((user: IUser)=>boolean);
 }
 
 export interface IViewPlugin {

--- a/tdp_core/db.py
+++ b/tdp_core/db.py
@@ -26,7 +26,7 @@ def _to_config(p):
     connector.statement_timeout_query = config.get('statement_timeout_query', default=None)
 
   if not connector.dburl:
-    _log.critical('no db url connector defined for %s at config key %s - is your configuration uptodate?', p.id, p.configKey)
+    _log.critical('no db url connector defined for %s at config key %s - is your configuration up to date?', p.id, p.configKey)
     raise NotImplementedError('missing db connector url')
 
   _log.info('%s -> %s', p.id, connector.dburl)

--- a/tdp_core/db.py
+++ b/tdp_core/db.py
@@ -25,6 +25,10 @@ def _to_config(p):
   if not connector.statement_timeout_query:
     connector.statement_timeout_query = config.get('statement_timeout_query', default=None)
 
+  if not connector.dburl:
+    _log.critical('no db url connector defined for %s at config key %s - is your configuration uptodate?', p.id, p.configKey)
+    raise NotImplementedError('missing db connector url')
+
   _log.info('%s -> %s', p.id, connector.dburl)
   engine_options = config.get('engine', default={})
   engine = sqlalchemy.create_engine(connector.dburl, **engine_options)

--- a/tdp_core/sql.py
+++ b/tdp_core/sql.py
@@ -29,7 +29,7 @@ def list_view(database):
   config_engine = db.resolve(database)
   if not config_engine:
     return 404, 'Not Found'
-  return jsonify([v.dump(k) for k, v in config_engine[0].views.items()])
+  return jsonify([v.dump(k) for k, v in config_engine[0].views.items() if v.can_access()])
 
 
 def _assign_ids(r, view):


### PR DESCRIPTION
fix #60 

added options: 

server side: `DBViewBuilder.security(rolename|(user)=>boolean)`
client side: part of `tdpView` extension definition: `security: (rolename|(user) => boolean)`

zB
```
 .security('admin')
 .security(lambda user: user.has_role('admin'))
```

```
  security: 'admin'
  security: function(user) { return user.roles.indexOf('admin') >= 0}
```