### PR TITLE
improved lineup color management

### DIFF
--- a/src/lineup/internal/LineUpColors.ts
+++ b/src/lineup/internal/LineUpColors.ts
@@ -7,10 +7,10 @@ export default class LineUpColors {
    * Map that assigns each selection ID a color, which is used as color for columns
    */
   private readonly colorMap = new Map<number, {color: string, items: number}>();
-  private colors: string[] = scale.category10().range().slice();
+  private colors: string[];
 
   init(ranking: Ranking) {
-    const colors = scale.category10().range().slice();
+    const colors = scale.category10().range().concat(scale.category20().range().filter((_d,i) => i % 2 === 1));;
     // remove colors that are already in use from the list
     ranking.flatColumns.forEach((d) => {
       const i = colors.indexOf(d.color);

--- a/src/lineup/internal/LineUpColors.ts
+++ b/src/lineup/internal/LineUpColors.ts
@@ -41,15 +41,14 @@ export default class LineUpColors {
   }
 
   freeColumnColor(id: number): void {
-    const {color} = this.colorMap.get(id);
-    let {items} = this.colorMap.get(id);
+    const value = this.colorMap.get(id);
 
-    if (color) {
-      items--;
-      if (items === 0) {
+    if (value.color) {
+      value.items--;
+      if (value.items === 0) {
         this.colorMap.delete(id);
       } else {
-        this.colorMap.set(id, {color, items});
+        this.colorMap.set(id, value);
       }
     }
   }

--- a/src/lineup/internal/LineUpColors.ts
+++ b/src/lineup/internal/LineUpColors.ts
@@ -40,9 +40,9 @@ export default class LineUpColors {
   }
 
   freeColumnColor(id: number): void {
-    const value = this.colorMap.get(id);
+    if(this.colorMap.has(id)) {
+      const value = this.colorMap.get(id);
 
-    if (value.color) {
       value.items--;
 
       if (value.items === 0) {

--- a/src/lineup/internal/LineUpColors.ts
+++ b/src/lineup/internal/LineUpColors.ts
@@ -50,4 +50,8 @@ export default class LineUpColors {
       }
     }
   }
+
+  clear() {
+    this.colorMap.clear();
+  }
 }

--- a/src/lineup/internal/LineUpColors.ts
+++ b/src/lineup/internal/LineUpColors.ts
@@ -10,7 +10,7 @@ export default class LineUpColors {
   private colors: string[];
 
   init(ranking: Ranking) {
-    const colors = scale.category10().range().concat(scale.category20().range().filter((_d,i) => i % 2 === 1));;
+    const colors = scale.category10().range().concat(scale.category20().range().filter((_d,i) => i % 2 === 1));
     // remove colors that are already in use from the list
     ranking.flatColumns.forEach((d) => {
       const i = colors.indexOf(d.color);
@@ -35,7 +35,6 @@ export default class LineUpColors {
       const value = this.colorMap.get(id);
       color = value.color;
       value.items++;
-      this.colorMap.set(id, value);
     }
     return color;
   }
@@ -45,10 +44,9 @@ export default class LineUpColors {
 
     if (value.color) {
       value.items--;
+
       if (value.items === 0) {
         this.colorMap.delete(id);
-      } else {
-        this.colorMap.set(id, value);
       }
     }
   }


### PR DESCRIPTION
- count how many items have the color before clearing it from the map
- avoid removing the color and then adding it back to the available colors, instead get the diff of the arrays and then get the first color