### PR TITLE
move swagger path description and summary for generic views into http…

### DIFF
--- a/tdp_core/swagger/view.tmpl.yml
+++ b/tdp_core/swagger/view.tmpl.yml
@@ -2,9 +2,9 @@ openapi: 3.0.0
 paths:
   {% if features.generic %}
   '/db/{{database}}/{{view}}':
-    summary: '{{summary}}'
-    description: '{{description}}'
     get:
+      summary: '{{summary}}'
+      description: '{{description}}'
       tags:
         - db_{{database}}
         - query_generic
@@ -30,9 +30,9 @@ paths:
   {%- endif %}
   {% if features.desc %}
   '/db/{{database}}/{{view}}/desc':
-    summary: '{{summary}}'
-    description: '{{description}}'
     get:
+      summary: '{{summary}}'
+      description: '{{description}}'
       tags:
         - db_{{database}}
         - query_generic
@@ -49,9 +49,9 @@ paths:
   {%- endif %}
   {% if features.lookup %}
   '/db/{{database}}/{{view}}/lookup':
-    summary: '{{summary}}'
-    description: '{{description}}'
     get:
+      summary: '{{summary}}'
+      description: '{{description}}'
       tags:
         - db_{{database}}
         - query_lookup
@@ -72,9 +72,9 @@ paths:
   {%- endif %}
   {% if features.score %}
   '/db/{{database}}/{{view}}/score':
-    summary: '{{summary}}'
-    description: '{{description}}'
     get:
+      summary: '{{summary}}'
+      description: '{{description}}'
       tags:
         - db_{{database}}
         - query_score


### PR DESCRIPTION
… method

The swagger UI did not show path descriptions and summaries as the json properties were appended to the path instead of the http method level. This PR fixes that by moving it one level down, e.g in yaml format: 

**current**:
```yaml
/generic/view/path:
    summary: 'some summary'
    description: 'any description'
    get:
      ...
```

**fix**:
```yaml
/generic/view/path:
    get:
      summary: 'some summary'
      description: 'any description'
      ...
```