### PR TITLE
Clehner/custom column colors

### DIFF
--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -45,7 +45,7 @@ export interface IScore<T> {
    * creates the LineUp column description
    * @returns {IColumnDesc & {[p: string]: any}}
    */
-  createDesc(): IColumnDesc & {[key: string]: any};
+  createDesc(extras?: object): IColumnDesc & {[key: string]: any};
 
 
   /**

--- a/src/lineup/ARankingView.ts
+++ b/src/lineup/ARankingView.ts
@@ -389,12 +389,14 @@ export abstract class ARankingView extends AView {
   }
 
   private addScoreColumn(score: IScore<any>) {
-    const colDesc = score.createDesc();
+    const args = typeof this.options.additionalComputeScoreParameter === 'function' ? this.options.additionalComputeScoreParameter() : this.options.additionalComputeScoreParameter;
+
+    const colDesc = score.createDesc(args);
     // flag that it is a score
     colDesc._score = true;
 
     const ids = this.selectionHelper.rowIdsAsSet(this.provider.getRankings()[0].getOrder());
-    const args = typeof this.options.additionalComputeScoreParameter === 'function' ? this.options.additionalComputeScoreParameter() : this.options.additionalComputeScoreParameter;
+
     const data = score.compute(ids, this.itemIDType, args);
     return this.addColumn(colDesc, data);
   }

--- a/src/lineup/ARankingView.ts
+++ b/src/lineup/ARankingView.ts
@@ -381,7 +381,7 @@ export abstract class ARankingView extends AView {
   }
 
   private addColumn(colDesc: any, data: Promise<IScoreRow<any>[]>, id = -1, position?: number): {col: Column, loaded: Promise<Column>} {
-    colDesc.color = this.colors.getColumnColor(id);
+    colDesc.color = colDesc.color? colDesc.color : this.colors.getColumnColor(id);
     return addLazyColumn(colDesc, data, this.provider, position, () => {
       this.taggle.update();
       this.panel.updateChooser(this.itemIDType, this.provider.getColumns());

--- a/src/lineup/desc.ts
+++ b/src/lineup/desc.ts
@@ -49,6 +49,12 @@ export interface IColumnOptions {
   selectedSubtype: string;
 
   /**
+   * set the column's color
+   * @default: ''
+   */
+  color: string;
+
+  /**
    * extra arguments
    */
   extras?: {[key: string]: any};

--- a/src/lineup/desc.ts
+++ b/src/lineup/desc.ts
@@ -49,12 +49,6 @@ export interface IColumnOptions {
   selectedSubtype: string;
 
   /**
-   * set the column's color
-   * @default: ''
-   */
-  color: string;
-
-  /**
    * extra arguments
    */
   extras?: {[key: string]: any};
@@ -91,7 +85,7 @@ export function numberColFromArray(column: string, rows: any[], options: Partial
 export function numberCol(column: string, min: number, max: number, options: Partial<IColumnOptions> = {}): IAdditionalColumnDesc {
   return Object.assign(baseColumn(column, options), {
     type: 'number',
-    domain: [min, max],
+    domain: [min, max]
   });
 }
 


### PR DESCRIPTION
I added some minor changes in order to set specific colors to instead of letting the color manager do all the work (there was also a `color` attribute in the basecolumn, which could not be set)