### PR TITLE
Sgratzl/advancedsec

### DIFF
--- a/src/ATDPApplication.ts
+++ b/src/ATDPApplication.ts
@@ -241,18 +241,17 @@ export abstract class ATDPApplication<T> extends ACLUEWrapper {
     if (plugins.length === 0) {
       return;
     }
-    Promise.all([<any>this.app, ...plugins.map((d) => d.load())]).then((args) => {
-      const appInstance = args[0];
-      const plugins: IAppExtensionExtension[] = args.slice(1);
-
-      for (const plugin of plugins) {
-        plugin.factory({
-          header: this.header,
-          content,
-          main,
-          app: appInstance
-        });
-      }
+    this.app.then((app) => {
+      Promise.all(plugins.map((d) => d.load())).then((plugins: IAppExtensionExtension[]) => {
+        for (const plugin of plugins) {
+          plugin.factory({
+            header: this.header,
+            content,
+            main,
+            app
+          });
+        }
+      });
     });
   }
 

--- a/src/internal/EditProvenanceGraphMenu.ts
+++ b/src/internal/EditProvenanceGraphMenu.ts
@@ -12,6 +12,7 @@ import {ALL_READ_NONE, ALL_READ_READ, EEntity, hasPermission, ISecureItem} from 
 import {IEvent, fire as globalFire} from 'phovea_core/src/event';
 import {DEFAULT_SUCCESS_AUTO_HIDE, pushNotification} from '../notifications';
 import {TemporarySessionList, PersistentSessionList} from '../SessionList';
+import {permissionForm} from './utils';
 
 declare const __DEBUG__;
 export const GLOBAL_EVENT_MANIPULATED = 'provenanceGraphMenuManipulated';
@@ -270,6 +271,11 @@ export function editProvenanceGraphMetaData(d: IProvenanceGraphDataDescription, 
   return lazyDialogModule().then(({FormDialog}) => {
     const dialog = new FormDialog(args.title, args.button);
     const prefix = 'd' + randomId();
+    const permissions = permissionForm(d, {
+      extra: `<div class="help-block">
+      Please ensure when publishing a session that associated datasets (i.e. uploaded datasets) are also public.
+    </div>`
+    });
     dialog.form.innerHTML = `
       <form>
           <div class="form-group">
@@ -280,17 +286,7 @@ export function editProvenanceGraphMetaData(d: IProvenanceGraphDataDescription, 
             <label for="${prefix}_desc">Description</label>
             <textarea class="form-control" id="${prefix}_desc" rows="3">${d.description || ''}</textarea>
           </div>
-          <div class="checkbox" ${!args.permission ? `style="display: none"` : ''}>
-            <label class="radio-inline">
-              <input type="radio" name="${prefix}_public" value="private" ${!isPublic(d) ? 'checked="checked"' : ''}> <i class="fa fa-user"></i> Private
-            </label>
-            <label class="radio-inline">
-              <input type="radio" name="${prefix}_public" id="${prefix}_public" value="public" ${isPublic(d) ? 'checked="checked"' : ''}> <i class="fa fa-users"></i> Public (everybody can see and use it)
-            </label>
-            <div class="help-block">
-              Please ensure when publishing a session that associated datasets (i.e. uploaded datasets) are also public.
-            </div>
-          </div>
+          ${args.permission ? permissions.template : ''}
           <div class="checkbox">
             <label class="radio-inline">
               <input type="checkbox" name="${prefix}_agree" required="required">
@@ -304,11 +300,10 @@ export function editProvenanceGraphMetaData(d: IProvenanceGraphDataDescription, 
         resolve(null);
       });
       dialog.onSubmit(() => {
-        const extras = {
+        const extras = Object.assign({
           name: (<HTMLInputElement>dialog.body.querySelector(`#${prefix}_name`)).value,
           description: (<HTMLTextAreaElement>dialog.body.querySelector(`#${prefix}_desc`)).value,
-          permissions: (<HTMLInputElement>dialog.body.querySelector(`#${prefix}_public`)).checked ? ALL_READ_READ : ALL_READ_NONE
-        };
+        }, args.permission ? permissions.resolve(new FormData(dialog.form)) : d.permissions);
         resolve(extras);
         dialog.hide();
         return false;

--- a/src/internal/EditProvenanceGraphMenu.ts
+++ b/src/internal/EditProvenanceGraphMenu.ts
@@ -277,24 +277,22 @@ export function editProvenanceGraphMetaData(d: IProvenanceGraphDataDescription, 
     </div>`
     });
     dialog.form.innerHTML = `
-      <form>
-          <div class="form-group">
-            <label for="${prefix}_name">Name</label>
-            <input type="text" class="form-control" id="${prefix}_name" value="${args.name}" required="required">
-          </div>
-          <div class="form-group">
-            <label for="${prefix}_desc">Description</label>
-            <textarea class="form-control" id="${prefix}_desc" rows="3">${d.description || ''}</textarea>
-          </div>
-          ${args.permission ? permissions.template : ''}
-          <div class="checkbox">
-            <label class="radio-inline">
-              <input type="checkbox" name="${prefix}_agree" required="required">
-              I agree that the current session will be stored on the application server in form of a provenance graph. Please note that you can delete sessions as part of the <strong>'Open Existing Session'</strong> dialog.
-            </label>
-          </div>
-      </form>
+        <div class="form-group">
+          <label for="${prefix}_name">Name</label>
+          <input type="text" class="form-control" id="${prefix}_name" value="${args.name}" required="required">
+        </div>
+        <div class="form-group">
+          <label for="${prefix}_desc">Description</label>
+          <textarea class="form-control" id="${prefix}_desc" rows="3">${d.description || ''}</textarea>
+        </div>
+        <div class="checkbox">
+          <label class="radio-inline">
+            <input type="checkbox" name="${prefix}_agree" required="required">
+            I agree that the current session will be stored on the application server in form of a provenance graph. Please note that you can delete sessions as part of the <strong>'Open Existing Session'</strong> dialog.
+          </label>
+        </div>
     `;
+    dialog.form.lastElementChild!.insertAdjacentElement('beforebegin', permissions.node);
     return new Promise((resolve) => {
       dialog.onHide(() => {
         resolve(null);

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -1,5 +1,5 @@
 import {randomId} from 'phovea_core/src';
-import {ALL_ALL_NONE_NONE, ALL_ALL_READ_NONE, ALL_ALL_READ_READ, ANONYMOUS_USER, currentUser, decode, EPermission, ISecureItem} from 'phovea_core/src/security';
+import {ALL_ALL_NONE_NONE, ALL_ALL_READ_NONE, ALL_ALL_READ_READ, ANONYMOUS_USER, currentUser, decode, EPermission, ISecureItem, Permission, encode} from 'phovea_core/src/security';
 
 const MIN = 60;
 const HOUR = MIN * 60;
@@ -82,14 +82,14 @@ export function permissionForm(item?: ISecureItem, options: Partial<IPermissionF
         <label>Public</label>
         <span></span>
         <div class="btn-group btn-group-xs" data-toggle="buttons">
-          <label class="btn btn-primary ${!permission.others.has(EPermission.READ)} ? 'active' : ''">
-            <input type="radio" name="permission_public" value="none" autocomplete="off" ${!permission.others.has(EPermission.READ) ? 'checked' : ''}> <i class="fa fa-user"></i> Private
+          <label class="btn btn-primary ${!permission.others.has(EPermission.READ) ? 'active' : ''}">
+            <input type="radio" name="permission_others" value="none" autocomplete="off" ${!permission.others.has(EPermission.READ) ? 'checked' : ''}> <i class="fa fa-user"></i> Private
           </label>
-          <label class="btn btn-primary ${permission.others.has(EPermission.READ)} ? 'active' : ''">
-            <input type="radio" name="permission_public" value="read" autocomplete="off" ${!permission.others.has(EPermission.READ) ? 'checked' : ''}> <i class="fa fa-eye"></i> Read
+          <label class="btn btn-primary ${permission.others.has(EPermission.READ) && !permission.others.has(EPermission.WRITE) ? 'active' : ''}">
+            <input type="radio" name="permission_others" value="read" autocomplete="off" ${permission.others.has(EPermission.READ) && !permission.others.has(EPermission.WRITE) ? 'checked' : ''}> <i class="fa fa-eye"></i> Read
           </label>
-          <label class="btn btn-primary ${permission.others.has(EPermission.WRITE)} ? 'active' : ''">
-            <input type="radio" name="permission_public" value="write" autocomplete="off" ${!permission.others.has(EPermission.READ) ? 'checked' : ''}> <i class="fa fa-edit"></i> Write
+          <label class="btn btn-primary ${permission.others.has(EPermission.WRITE) ? 'active' : ''}">
+            <input type="radio" name="permission_others" value="write" autocomplete="off" ${permission.others.has(EPermission.WRITE) ? 'checked' : ''}> <i class="fa fa-edit"></i> Write
           </label>
         </div>
       </div>
@@ -102,14 +102,14 @@ export function permissionForm(item?: ISecureItem, options: Partial<IPermissionF
           ${roles.map((d) => `<option value="${d}" ${item && item.group === d ? 'selected' : ''}>${d}</option>`).join('')}
         </select>
         <div class="btn-group btn-group-xs" data-toggle="buttons">
-          <label class="btn btn-primary ${!permission.others.has(EPermission.READ)} ? 'active' : ''">
-            <input type="radio" name="permission_group" value="none" autocomplete="off" ${!permission.others.has(EPermission.READ) ? 'checked' : ''}> <i class="fa fa-user"></i> Private
+          <label class="btn btn-primary ${!permission.group.has(EPermission.READ) ? 'active' : ''}">
+            <input type="radio" name="permission_group" value="none" autocomplete="off" ${!permission.group.has(EPermission.READ) ? 'checked' : ''}> <i class="fa fa-user"></i> Private
           </label>
-          <label class="btn btn-primary ${!permission.others.has(EPermission.READ)} ? 'active' : ''">
-            <input type="radio" name="permission_group" value="read" autocomplete="off" ${!permission.others.has(EPermission.READ) ? 'checked' : ''}> <i class="fa fa-eye"></i> Read
+          <label class="btn btn-primary ${permission.group.has(EPermission.READ) && !permission.group.has(EPermission.WRITE) ? 'active' : ''}">
+            <input type="radio" name="permission_group" value="read" autocomplete="off" ${permission.group.has(EPermission.READ) && !permission.group.has(EPermission.WRITE) ? 'checked' : ''}> <i class="fa fa-eye"></i> Read
           </label>
-          <label class="btn btn-primary ${!permission.others.has(EPermission.READ)} ? 'active' : ''">
-            <input type="radio" name="permission_group" value="write" autocomplete="off" ${!permission.others.has(EPermission.READ) ? 'checked' : ''}> <i class="fa fa-edit"></i> Write
+          <label class="btn btn-primary ${permission.group.has(EPermission.WRITE) ? 'active' : ''}">
+            <input type="radio" name="permission_group" value="write" autocomplete="off" ${permission.group.has(EPermission.WRITE) ? 'checked' : ''}> <i class="fa fa-edit"></i> Write
           </label>
         </div>
       </div>
@@ -120,14 +120,14 @@ export function permissionForm(item?: ISecureItem, options: Partial<IPermissionF
         <label for="permission_buddies_name_${id}">Buddies</label>
         <input id="permission_buddies_name_${id}" name="permission_buddies_name" class="form-control input-sm" placeholder="list of usernames separated by semicolon" value="${item && item.buddies ? item.buddies.join(';') : ''}">
         <div class="btn-group btn-group-xs" data-toggle="buttons">
-          <label class="btn btn-primary ${!permission.others.has(EPermission.READ)} ? 'active' : ''">
-            <input type="radio" name="permission_buddies" value="none" autocomplete="off" ${!permission.others.has(EPermission.READ) ? 'checked' : ''}> <i class="fa fa-user"></i> Private
+          <label class="btn btn-primary ${!permission.buddies.has(EPermission.READ) ? 'active' : ''}">
+            <input type="radio" name="permission_buddies" value="none" autocomplete="off" ${!permission.buddies.has(EPermission.READ) ? 'checked' : ''}> <i class="fa fa-user"></i> Private
           </label>
-          <label class="btn btn-primary ${!permission.others.has(EPermission.READ)} ? 'active' : ''">
-            <input type="radio" name="permission_buddies" value="read" autocomplete="off" ${!permission.others.has(EPermission.READ) ? 'checked' : ''}> <i class="fa fa-eye"></i> Read
+          <label class="btn btn-primary ${permission.buddies.has(EPermission.READ) && !permission.buddies.has(EPermission.WRITE) ? 'active' : ''}">
+            <input type="radio" name="permission_buddies" value="read" autocomplete="off" ${permission.buddies.has(EPermission.READ) && !permission.buddies.has(EPermission.WRITE) ? 'checked' : ''}> <i class="fa fa-eye"></i> Read
           </label>
-          <label class="btn btn-primary ${!permission.others.has(EPermission.READ)} ? 'active' : ''">
-            <input type="radio" name="permission_buddies" value="write" autocomplete="off" ${!permission.others.has(EPermission.READ) ? 'checked' : ''}> <i class="fa fa-edit"></i> Write
+          <label class="btn btn-primary ${permission.buddies.has(EPermission.WRITE) ? 'active' : ''}">
+            <input type="radio" name="permission_buddies" value="write" autocomplete="off" ${permission.buddies.has(EPermission.WRITE) ? 'checked' : ''}> <i class="fa fa-edit"></i> Write
           </label>
         </div>
       </div>
@@ -142,12 +142,82 @@ export function permissionForm(item?: ISecureItem, options: Partial<IPermissionF
     div.classList.toggle('tdp-permissions-open');
   };
 
+  const publicSimple = Array.from(div.querySelectorAll<HTMLInputElement>('input[name=permission_public]'));
+  const others = Array.from(div.querySelectorAll<HTMLInputElement>('input[name=permission_others]'));
+  const group = Array.from(div.querySelectorAll<HTMLInputElement>('input[name=permission_group]'));
+  const buddies = Array.from(div.querySelectorAll<HTMLInputElement>('input[name=permission_buddies]'));
+
+  const syncActive = () => {
+    others.forEach((d) => d.parentElement.classList.toggle('active', d.checked));
+    group.forEach((d) => d.parentElement.classList.toggle('active', d.checked));
+    buddies.forEach((d) => d.parentElement.classList.toggle('active', d.checked));
+  };
+
+  publicSimple.forEach((d) => {
+    d.onchange = () => {
+      if (!d.checked) {
+        return;
+      }
+      // sync with others
+      const target = d.value === 'public' ? 'read' : 'none';
+      others.forEach((o) => o.checked = o.value === target);
+      const groupSelected = group.find((d) => d.checked);
+      if (groupSelected && groupSelected.value === 'none') {
+        group.forEach((i) => i.checked = i.value === target);
+      }
+      const buddiesSelected = buddies.find((d) => d.checked);
+      if (buddiesSelected && buddiesSelected.value === 'none') {
+        buddies.forEach((d) => d.checked = d.value === target);
+      }
+      syncActive();
+    };
+  });
+  others.forEach((clicked) => {
+    clicked.onchange = () => {
+      if (!clicked.checked) {
+        return;
+      }
+      // sync with public
+      {
+        const target = clicked.value === 'none' ? 'private' : 'public';
+        publicSimple.forEach((o) => o.checked = o.value === target);
+      }
+      // others at least with the same right
+      if (clicked.value === 'read' || clicked.value === 'write') {
+        const groupSelected = group.find((d) => d.checked);
+        if (groupSelected && (groupSelected.value === 'none' || (groupSelected.value === 'read' && clicked.value === 'write'))) {
+          group.forEach((i) => i.checked = i.value === clicked.value);
+        }
+        const buddiesSelected = buddies.find((d) => d.checked);
+        if (buddiesSelected && (buddiesSelected.value === 'none' || (buddiesSelected.value === 'read' && clicked.value === 'write'))) {
+          buddies.forEach((d) => d.checked = d.value === clicked.value);
+        }
+      }
+      syncActive();
+    };
+  });
+
+  const toSet = (value: string) => {
+    if (value === 'read') {
+      return new Set([EPermission.READ]);
+    } else if (value === 'write') {
+      return new Set([EPermission.READ, EPermission.WRITE]);
+    }
+    return new Set();
+  };
+
   return {
     node: div,
     resolve: (data: FormData): Partial<ISecureItem> => {
-      const makePublic = data.get('permission_public').toString();
+      const others = toSet(data.get('permission_others').toString());
+      const group = toSet(data.get('permission_group').toString());
+      const groupName = data.get('permission_group_name').toString();
+      const buddies = toSet(data.get('permission_buddies').toString());
+      const buddiesName = data.get('permission_buddies_name').toString().split(';').map((d) => d.trim()).filter((d) => d.length > 0);
       return {
-        permissions: makePublic === 'public' ? ALL_ALL_READ_READ : ALL_ALL_NONE_NONE
+        permissions: encode(new Set([EPermission.READ, EPermission.WRITE, EPermission.EXECUTE]), group, others, buddies),
+        group: groupName,
+        buddies: buddiesName
       };
     }
   };

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -1,3 +1,5 @@
+import {ISecureItem, hasPermission, EEntity, ALL_READ_NONE, ALL_READ_READ, ALL_NONE_NONE, ALL_ALL_NONE_NONE, ALL_ALL_READ_READ, decode} from 'phovea_core/src/security';
+
 const MIN = 60;
 const HOUR = MIN * 60;
 const DAY = HOUR * 24;
@@ -37,3 +39,100 @@ export function fromNow(date: Date | number) {
 export function notAllowedText(notAllowed: boolean | string) {
   return (typeof notAllowed === 'string' ? notAllowed : 'Not Allowed, please contact your system administrator');
 }
+
+
+export interface IPermissionFormOptions {
+  /**
+   * extra html
+   */
+  extra: string;
+}
+
+/**
+ * utilitly for adding a permission form as used in TDP by default
+ * @param item
+ */
+export function permissionForm(item?: ISecureItem, options: Partial<IPermissionFormOptions> = {}) {
+  const o: Readonly<IPermissionFormOptions> = Object.assign({
+    extra: ''
+  }, options);
+  return {
+    template: `
+    <div class="radio">
+      <label class="radio-inline">
+        <input type="radio" name="permission_public" value="private" ${!(item && hasPermission(item, EEntity.OTHERS)) ? 'checked="checked"' : ''}> <i class="fa fa-user"></i> Private
+      </label>
+      <label class="radio-inline">
+        <input type="radio" name="permission_public" value="public" ${item && hasPermission(item, EEntity.OTHERS) ? 'checked="checked"' : ''}> <i class="fa fa-users"></i> Public (everybody can see and use it)
+      </label>
+      ${o.extra}
+    </div>
+    `,
+    resolve: (data: FormData): Partial<ISecureItem> => {
+      const makePublic = data.get('permission_public').toString();
+      return {
+        permissions: makePublic === 'public' ? ALL_ALL_READ_READ : ALL_ALL_NONE_NONE
+      };
+    }
+  };
+}
+
+const per = decode();
+const a =
+`<div class="tdp-permissions">
+  <div>
+    <label>Public</label>
+    <span></span>
+    <div class="btn-group" data-toggle="buttons">
+      <label class="btn btn-primary active">
+        <input type="radio" name="permission_public" value="none" autocomplete="off" checked> <i class="fa fa-user"></i> Private
+      </label>
+      <label class="btn btn-primary">
+        <input type="radio" name="permission_public" value="read" autocomplete="off"> <i class="fa fa-eye"></i> Read
+      </label>
+      <label class="btn btn-primary">
+        <input type="radio" name="permission_public" value="write" autocomplete="off"> <i class="fa fa-edit"></i> Write
+      </label>
+    </div>
+    <p class="help-block">
+      define which are the default permissions for other users to access this item
+    </p>
+  </div>
+  <div>
+     <label>Group</label>
+     <select name="permission_group_name" class="form-control">
+     </select
+     <div class="btn-group" data-toggle="buttons">
+       <label class="btn btn-primary active">
+         <input type="radio" name="permission_group" value="none" autocomplete="off" checked> <i class="fa fa-user"></i> Private
+       </label>
+       <label class="btn btn-primary">
+         <input type="radio" name="permission_group" value="read" autocomplete="off"> <i class="fa fa-eye"></i> Read
+       </label>
+       <label class="btn btn-primary">
+         <input type="radio" name="permission_group" value="write" autocomplete="off"> <i class="fa fa-edit"></i> Write
+       </label>
+     </div>
+     <p class="help-block">
+       specify a group / role which you are part of that should extra rights, such as a group of administrators
+     </p>
+  </div>
+  <div>
+    <label>Buddies</label>
+    <input name="permission_buddies_name" class="form-control">
+    <div class="btn-group" data-toggle="buttons">
+      <label class="btn btn-primary active">
+        <input type="radio" name="permission_buddies" value="none" autocomplete="off" checked> <i class="fa fa-user"></i> Private
+      </label>
+      <label class="btn btn-primary">
+        <input type="radio" name="permission_buddies" value="read" autocomplete="off"> <i class="fa fa-eye"></i> Read
+      </label>
+      <label class="btn btn-primary">
+        <input type="radio" name="permission_buddies" value="write" autocomplete="off"> <i class="fa fa-edit"></i> Write
+      </label>
+    </div>
+    <p class="help-block">
+      Buddies are a list of user names that can have advanced rights, such as backup administrators
+    </p>
+  </div>
+`

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -140,6 +140,7 @@ export function permissionForm(item?: ISecureItem, options: Partial<IPermissionF
     evt.preventDefault();
     evt.stopPropagation();
     div.classList.toggle('tdp-permissions-open');
+    (<HTMLElement>evt.target).classList.toggle('active');
   };
 
   const publicSimple = Array.from(div.querySelectorAll<HTMLInputElement>('input[name=permission_public]'));

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -83,7 +83,7 @@ export function permissionForm(item?: ISecureItem, options: Partial<IPermissionF
         <span></span>
         <div class="btn-group btn-group-xs" data-toggle="buttons">
           <label class="btn btn-primary ${!permission.others.has(EPermission.READ) ? 'active' : ''}">
-            <input type="radio" name="permission_others" value="none" autocomplete="off" ${!permission.others.has(EPermission.READ) ? 'checked' : ''}> <i class="fa fa-user"></i> Private
+            <input type="radio" name="permission_others" value="none" autocomplete="off" ${!permission.others.has(EPermission.READ) ? 'checked' : ''}> <i class="fa fa-user"></i> No Permission
           </label>
           <label class="btn btn-primary ${permission.others.has(EPermission.READ) && !permission.others.has(EPermission.WRITE) ? 'active' : ''}">
             <input type="radio" name="permission_others" value="read" autocomplete="off" ${permission.others.has(EPermission.READ) && !permission.others.has(EPermission.WRITE) ? 'checked' : ''}> <i class="fa fa-eye"></i> Read
@@ -103,7 +103,7 @@ export function permissionForm(item?: ISecureItem, options: Partial<IPermissionF
         </select>
         <div class="btn-group btn-group-xs" data-toggle="buttons">
           <label class="btn btn-primary ${!permission.group.has(EPermission.READ) ? 'active' : ''}">
-            <input type="radio" name="permission_group" value="none" autocomplete="off" ${!permission.group.has(EPermission.READ) ? 'checked' : ''}> <i class="fa fa-user"></i> Private
+            <input type="radio" name="permission_group" value="none" autocomplete="off" ${!permission.group.has(EPermission.READ) ? 'checked' : ''}> <i class="fa fa-user"></i> No Permission
           </label>
           <label class="btn btn-primary ${permission.group.has(EPermission.READ) && !permission.group.has(EPermission.WRITE) ? 'active' : ''}">
             <input type="radio" name="permission_group" value="read" autocomplete="off" ${permission.group.has(EPermission.READ) && !permission.group.has(EPermission.WRITE) ? 'checked' : ''}> <i class="fa fa-eye"></i> Read
@@ -121,7 +121,7 @@ export function permissionForm(item?: ISecureItem, options: Partial<IPermissionF
         <input id="permission_buddies_name_${id}" name="permission_buddies_name" class="form-control input-sm" placeholder="list of usernames separated by semicolon" value="${item && item.buddies ? item.buddies.join(';') : ''}">
         <div class="btn-group btn-group-xs" data-toggle="buttons">
           <label class="btn btn-primary ${!permission.buddies.has(EPermission.READ) ? 'active' : ''}">
-            <input type="radio" name="permission_buddies" value="none" autocomplete="off" ${!permission.buddies.has(EPermission.READ) ? 'checked' : ''}> <i class="fa fa-user"></i> Private
+            <input type="radio" name="permission_buddies" value="none" autocomplete="off" ${!permission.buddies.has(EPermission.READ) ? 'checked' : ''}> <i class="fa fa-user"></i> No Permission
           </label>
           <label class="btn btn-primary ${permission.buddies.has(EPermission.READ) && !permission.buddies.has(EPermission.WRITE) ? 'active' : ''}">
             <input type="radio" name="permission_buddies" value="read" autocomplete="off" ${permission.buddies.has(EPermission.READ) && !permission.buddies.has(EPermission.WRITE) ? 'checked' : ''}> <i class="fa fa-eye"></i> Read

--- a/src/lineup/ARankingView.ts
+++ b/src/lineup/ARankingView.ts
@@ -19,6 +19,7 @@ import {IServerColumn, IViewDescription} from '../rest';
 import LineUpPanelActions, {rule} from './internal/LineUpPanelActions';
 import {addLazyColumn} from './internal/column';
 import {successfullySaved} from '../notifications';
+import {ISecureItem} from 'phovea_core/src/security';
 
 export {IRankingWrapper} from './internal/ranking';
 export {LocalDataProvider as DataProvider} from 'lineupjs';
@@ -207,8 +208,8 @@ export abstract class ARankingView extends AView {
     }));
 
     this.panel = new LineUpPanelActions(this.provider, this.taggle.ctx, this.options, this.node.ownerDocument);
-    this.panel.on(LineUpPanelActions.EVENT_SAVE_NAMED_SET, (_event, order: number[], name: string, description: string, isPublic: boolean) => {
-      this.saveNamedSet(order, name, description, isPublic);
+    this.panel.on(LineUpPanelActions.EVENT_SAVE_NAMED_SET, (_event, order: number[], name: string, description: string, sec: Partial<ISecureItem>) => {
+      this.saveNamedSet(order, name, description, sec);
     });
     this.panel.on(LineUpPanelActions.EVENT_ADD_SCORE_COLUMN, (_event, scoreImpl: IScore<any>) => {
       this.addScoreColumn(scoreImpl);
@@ -378,9 +379,9 @@ export abstract class ARankingView extends AView {
   }
 
 
-  private async saveNamedSet(order: number[], name: string, description: string, isPublic: boolean = false) {
+  private async saveNamedSet(order: number[], name: string, description: string, sec: Partial<ISecureItem>) {
     const ids = this.selectionHelper.rowIdsAsSet(order);
-    const namedSet = await saveNamedSet(name, this.itemIDType, ids, this.options.subType, description, isPublic);
+    const namedSet = await saveNamedSet(name, this.itemIDType, ids, this.options.subType, description, sec);
     successfullySaved('List of Entities', name);
     this.fire(AView.EVENT_UPDATE_ENTRY_POINT, namedSet);
   }

--- a/src/lineup/internal/LineUpPanelActions.ts
+++ b/src/lineup/internal/LineUpPanelActions.ts
@@ -284,8 +284,8 @@ export default class LineUpPanelActions extends EventHandler {
   }
 
   protected saveRankingDialog(order: number[]) {
-    editDialog(null, (name, description, isPublic) => {
-      this.fire(LineUpPanelActions.EVENT_SAVE_NAMED_SET, order, name, description, isPublic);
+    editDialog(null, (name, description, sec) => {
+      this.fire(LineUpPanelActions.EVENT_SAVE_NAMED_SET, order, name, description, sec);
     });
   }
 

--- a/src/storage/NamedSetList.ts
+++ b/src/storage/NamedSetList.ts
@@ -57,12 +57,11 @@ export default class NamedSetList {
     if (!canWrite(namedSet)) {
       return;
     }
-    editDialog(namedSet, async (name, description, isPublic) => {
-      const params = {
+    editDialog(namedSet, async (name, description, sec) => {
+      const params = Object.assign({
         name,
-        description,
-        permissions: isPublic ? ALL_READ_READ : ALL_NONE_NONE
-      };
+        description
+      }, sec);
 
       const editedSet = await editNamedSet(namedSet.id, params);
       successfullySaved('Named Set', name);

--- a/src/storage/editDialog.ts
+++ b/src/storage/editDialog.ts
@@ -19,8 +19,8 @@ export default function editDialog(namedSet: IStoredNamedSet, result: (name: str
       <label for="namedset_description">Description</label>
       <textarea class="form-control" name="description" id="namedset_description" rows="5" placeholder="Description">${namedSet ? namedSet.description : ''}</textarea>
     </div>
-    ${permissions.template}
   `;
+  dialog.form.appendChild(permissions.node);
 
   dialog.onHide(() => dialog.destroy());
 

--- a/src/storage/rest.ts
+++ b/src/storage/rest.ts
@@ -1,7 +1,7 @@
 import {api2absURL, send, getAPIJSON, sendAPI} from 'phovea_core/src/ajax';
 import {IDType, resolve} from 'phovea_core/src/idtype';
 import {parse, RangeLike} from 'phovea_core/src/range';
-import {currentUserNameOrAnonymous, ALL_READ_NONE, ALL_READ_READ} from 'phovea_core/src/security';
+import {currentUserNameOrAnonymous, ALL_READ_NONE, ALL_READ_READ, ISecureItem} from 'phovea_core/src/security';
 import {REST_NAMESPACE as TDP_NAMESPACE} from '../rest';
 import {ENamedSetType, IStoredNamedSet} from './interfaces';
 
@@ -21,18 +21,18 @@ export function listNamedSetsAsOptions(idType: IDType | string = null) {
   return listNamedSets(idType).then((namedSets) => namedSets.map((d) => ({name: d.name, value: d.id})));
 }
 
-export function saveNamedSet(name: string, idType: IDType | string, ids: RangeLike, subType: { key: string, value: string }, description = '', isPublic: boolean = false) {
-  const data = {
+export function saveNamedSet(name: string, idType: IDType | string, ids: RangeLike, subType: { key: string, value: string }, description = '', sec: Partial<ISecureItem>) {
+  const data = Object.assign({
     name,
     type: ENamedSetType.NAMEDSET,
     creator: currentUserNameOrAnonymous(),
-    permissions: isPublic ? ALL_READ_READ : ALL_READ_NONE,
+    permissions: ALL_READ_NONE,
     idType: resolve(idType).id,
     ids: parse(ids).toString(),
     subTypeKey: subType.key,
     subTypeValue: subType.value,
     description
-  };
+  }, sec);
   return sendAPI(`${REST_NAMESPACE}/namedsets/`, data, 'POST');
 }
 

--- a/src/styles/_permissions.scss
+++ b/src/styles/_permissions.scss
@@ -11,9 +11,11 @@
 .tdp-permissions-entry {
   display: flex;
   align-items: center;
+  margin-top: 2em;
 
   > label {
     min-width: 6em;
+    padding-left: 0;
   }
 
   > span,

--- a/src/styles/_permissions.scss
+++ b/src/styles/_permissions.scss
@@ -1,0 +1,25 @@
+
+
+.tdp-permissions {
+  display: none;
+}
+
+.tdp-permissions-open > .tdp-permissions {
+  display: block;
+}
+
+.tdp-permissions-entry {
+  display: flex;
+  align-items: center;
+
+  > label {
+    min-width: 6em;
+  }
+
+  > span,
+  > input,
+  > select {
+    flex: 1 1 0;
+    margin: 0 0.5em;
+  }
+}

--- a/src/styles/_permissions.scss
+++ b/src/styles/_permissions.scss
@@ -24,4 +24,8 @@
     flex: 1 1 0;
     margin: 0 0.5em;
   }
+
+  > div.btn-group label input[name*=permission_] {
+    display: none;
+  }
 }

--- a/src/styles/_tdp.scss
+++ b/src/styles/_tdp.scss
@@ -10,6 +10,7 @@
 @import './dialogs';
 @import './tooltip';
 @import './tour';
+@import './permissions';
 
 $lu_assets: '~lineupjs/src/assets';
 


### PR DESCRIPTION
implement a common permission form component to edit advanced permissions for an item. 

e.g. during persisting the provenance graph

![image](https://user-images.githubusercontent.com/4129778/50763192-67950500-126f-11e9-9dbf-95105d875c52.png)
