### PR TITLE
fix Select3 invalidating already successfully validated items

### DIFF
--- a/src/form/internal/Select3.ts
+++ b/src/form/internal/Select3.ts
@@ -486,7 +486,7 @@ export default class Select3<T extends IdTextPair> extends EventHandler {
         const original = i.text;
         const valid = validated.get(original.toLowerCase());
         const dom = <HTMLElement>processing.find((d) => d.textContent.endsWith(original));
-        if (!valid) {
+        if (!valid && i.verified !== 'verified') {
           i.verified = 'invalid';
         } else {
           // remove key


### PR DESCRIPTION
this fixes the problem that with Select3 previously successfully verified genes were suddenly invalid when entering some invalid strings. see:
![ordino_select3](https://user-images.githubusercontent.com/1711080/57852302-18457f00-77e3-11e9-889c-26ba8b828493.gif)