### PR TITLE
Fix valid replacements type check in DBView

### DIFF
--- a/tdp_core/dbview.py
+++ b/tdp_core/dbview.py
@@ -107,14 +107,14 @@ class DBView(object):
       return value in v
     if v == int:
       try:
-        int(value) # try to cast value to int
-        return True # successful type cast
+        int(value)  # try to cast value to int
+        return True  # successful type cast
       except ValueError:
         return False
     if v == float:
       try:
-        float(value) # try to cast value to float
-        return True # successful type cast
+        float(value)  # try to cast value to float
+        return True  # successful type cast
       except ValueError:
         return False
     if isinstance(v, REGEX_TYPE):

--- a/tdp_core/dbview.py
+++ b/tdp_core/dbview.py
@@ -105,8 +105,18 @@ class DBView(object):
     v = self.valid_replacements[key]
     if isinstance(v, list):
       return value in v
-    if v == int or v == float:
-      return type(value) == v
+    if v == int:
+      try:
+        int(value) # try to cast value to int
+        return True # successful type cast
+      except ValueError:
+        return False
+    if v == float:
+      try:
+        float(value) # try to cast value to float
+        return True # successful type cast
+      except ValueError:
+        return False
     if isinstance(v, REGEX_TYPE):
       return v.match(value)
     _log.info(u'unknown %s %s %s', key, value, v)


### PR DESCRIPTION
**Example**
```py
views['multiply_age_score'] = DBViewBuilder().idtype(idtype) \
  .query("""SELECT id, (age * {multiplicator}) AS score FROM persons""") \
  .replace('multiplicator', int) \
  .call(inject_where) \
  .build()
```

**API calls**

1. Valid API call with _int_: http://localhost:8080/api/tdp/db/patientdb/multiply_age_score/score?multiplicator=1
2. Invalid API call with _string_: http://localhost:8080/api/tdp/db/patientdb/multiply_age_score/score?multiplicator=test

**Result before PR**
Both API calls are failing, because the value of _multiplicator_ is the Python type _unicode_. Same behavior applies for _float_.

**Change**
* Try to cast the value to int/float
* If the cast succeeds, the value is a valid int/float
* Otherwise raises an error and no valid replacement

**Result after PR**
API calls with integer values are successful, while string values are failing.