### PR TITLE
Fix if a tdp config key cannot be found

### DIFF
--- a/tdp_core/config.py
+++ b/tdp_core/config.py
@@ -1,4 +1,4 @@
-from phovea_server.ns import Namespace
+from phovea_server.ns import Namespace,abort
 from phovea_server.util import jsonify
 from phovea_server.config import get as get_config
 from phovea_server.plugin import list as list_plugins
@@ -14,8 +14,10 @@ def _config(path):
   key = path[0]
 
   plugin = next((p for p in list_plugins('tdp-config-safe-keys') if p.id == key), None)
-  if not plugin:
-    return 404, 'key not found'
+
+  if plugin is None:
+    _log.error('404: config key "{}" not found'.format(key))
+    abort(404, u'config key "{}" not found'.format(key))
 
   path[0] = plugin.configKey
   return jsonify(get_config('.'.join(path)))

--- a/tdp_core/config.py
+++ b/tdp_core/config.py
@@ -1,4 +1,4 @@
-from phovea_server.ns import Namespace,abort
+from phovea_server.ns import Namespace, abort
 from phovea_server.util import jsonify
 from phovea_server.config import get as get_config
 from phovea_server.plugin import list as list_plugins


### PR DESCRIPTION
Related issue Caleydo/ordino#204

**Before**

When a config key is retrieved that is not available an internal server error was raised (see Caleydo/ordino#204).

**Now**

The return value for the error 404 was incorrect. Instead I'm using Flask's `abort` function, similar to for instance [storage.py](https://github.com/datavisyn/tdp_core/blob/88807bc05d7ecdb95d7be6dbc6754671936ba3f1/tdp_core/storage.py#L53).

![image](https://user-images.githubusercontent.com/5851088/61435854-c54e8c00-a939-11e9-8c8a-599a2a8eeb45.png)
