### PR TITLE
Remove D3 from form builder

### DIFF
--- a/src/form/FormBuilder.ts
+++ b/src/form/FormBuilder.ts
@@ -2,7 +2,6 @@
  * Created by Samuel Gratzl on 08.03.2017.
  */
 
-import * as d3 from 'd3';
 import {randomId} from 'phovea_core/src/index';
 import {IFormElement, IFormElementDesc, IForm} from './interfaces';
 import {create} from './internal';
@@ -25,11 +24,11 @@ export default class FormBuilder {
 
   /**
    * Constructor
-   * @param $parent Node that the form should be attached to
+   * @param parentElement DOM element that the form should be attached to
    * @param formId unique form id
    */
-  constructor($parent: d3.Selection<any>, private readonly formId = randomId()) {
-    this.form = new Form($parent, formId);
+  constructor(parentElement: HTMLElement, private readonly formId = randomId()) {
+    this.form = new Form(parentElement, formId);
   }
 
   /**
@@ -40,7 +39,7 @@ export default class FormBuilder {
   appendElement(elementDesc: IFormElementDesc) {
     const desc = updateElementDesc(elementDesc, this.formId);
 
-    const elementPromise = create(this.form, this.form.$node, desc);
+    const elementPromise = create(this.form, this.form.node, desc);
     this.elementPromises.push(elementPromise);
 
     // append element to form once it is loaded

--- a/src/form/FormDialog.ts
+++ b/src/form/FormDialog.ts
@@ -5,7 +5,6 @@ import {FormDialog as Dialog} from 'phovea_ui/src/dialogs';
 import {randomId} from 'phovea_core/src';
 import FormBuilder from './FormBuilder';
 import {IFormElementDesc, IForm} from './interfaces';
-import {select} from 'd3';
 
 /**
  * a utililty dialog to show a dialog modal using a FormBuilder
@@ -22,7 +21,7 @@ export default class FormDialog extends Dialog {
   constructor(title: string, primaryButton: string, formId = 'form' + randomId(5)) {
     super(title, primaryButton, formId);
     this.body.innerHTML = ''; //clear old form since the form builder brings its own
-    this.builder = new FormBuilder(select(this.body), formId);
+    this.builder = new FormBuilder(this.body, formId);
 
     this.onHide(() => {
       this.destroy();

--- a/src/form/interfaces.ts
+++ b/src/form/interfaces.ts
@@ -146,9 +146,9 @@ export interface IFormElementDesc {
 
 export interface IForm {
   /**
-   * The DOM node as D3 selection
+   * The DOM node of the form
    */
-  $node: d3.Selection<any>;
+  node: HTMLElement;
 
   /**
    * Append a form element and builds it

--- a/src/form/internal/AFormElement.ts
+++ b/src/form/internal/AFormElement.ts
@@ -2,7 +2,6 @@
  * Created by Samuel Gratzl on 08.03.2017.
  */
 
-import {Selection} from 'd3';
 import {EventHandler} from 'phovea_core/src/event';
 import {IFormElementDesc, IForm, IFormElement} from '../interfaces';
 import * as session from 'phovea_core/src/session';
@@ -16,7 +15,7 @@ export abstract class AFormElement<T extends IFormElementDesc> extends EventHand
 
   readonly id: string;
 
-  protected $node: Selection<any>;
+  protected node: HTMLElement;
 
   protected previousValue: any = null;
 
@@ -63,7 +62,7 @@ export abstract class AFormElement<T extends IFormElementDesc> extends EventHand
       return true;
     }
     const v = this.hasValue();
-    this.$node.classed('has-error', !v);
+    this.node.classList.toggle('has-error', !v);
     return v;
   }
 
@@ -72,7 +71,7 @@ export abstract class AFormElement<T extends IFormElementDesc> extends EventHand
   }
 
   isVisible() {
-    return !this.$node.classed('hidden');
+    return !this.node.classList.toggle('hidden');
   }
 
   /**
@@ -80,7 +79,7 @@ export abstract class AFormElement<T extends IFormElementDesc> extends EventHand
    * @param visible
    */
   setVisible(visible: boolean) {
-    this.$node.classed('hidden', !visible);
+    this.node.classList.toggle('hidden', !visible);
   }
 
   protected addChangeListener() {
@@ -106,11 +105,14 @@ export abstract class AFormElement<T extends IFormElementDesc> extends EventHand
     this.addChangeListener();
 
     if (this.desc.visible === false) {
-      this.$node.classed('hidden', true);
+      this.node.classList.toggle('hidden', true);
     }
 
     if (!this.desc.hideLabel) {
-      this.$node.append('label').attr('for', this.desc.attributes.id).text(this.desc.label);
+      const label = this.node.ownerDocument.createElement('label');
+      label.setAttribute('for', this.desc.attributes.id);
+      label.innerText = this.desc.label;
+      this.node.appendChild(label);
     }
   }
 
@@ -124,21 +126,21 @@ export abstract class AFormElement<T extends IFormElementDesc> extends EventHand
   /**
    * Set a list of object properties and values to a given node
    * Note: Use `clazz` instead of the attribute `class` (which is a reserved keyword in JavaScript)
-   * @param $node
+   * @param node
    * @param attributes Plain JS object with key as attribute name and the value as attribute value
    */
-  protected setAttributes($node: Selection<any>, attributes: {[key: string]: any}) {
+  protected setAttributes(node: HTMLElement, attributes: {[key: string]: any}) {
     if (!attributes) {
       return;
     }
 
     Object.keys(attributes).forEach((key) => {
-      $node.attr((key === 'clazz') ? 'class' : key, attributes[key]);
+      node.setAttribute((key === 'clazz') ? 'class' : key, attributes[key]);
     });
 
     if (this.desc.required && !this.desc.showIf) {
       // auto enable just if there is no conditional viewing
-      $node.attr('required', 'required');
+      node.setAttribute('required', 'required');
     }
   }
 
@@ -158,7 +160,7 @@ export abstract class AFormElement<T extends IFormElementDesc> extends EventHand
           onDependentChange(values);
         }
         if (showIf) {
-          this.$node.classed('hidden', !showIf(values));
+          this.node.classList.toggle('hidden', !showIf(values));
         }
       });
     });
@@ -166,7 +168,7 @@ export abstract class AFormElement<T extends IFormElementDesc> extends EventHand
     // initial values
     const values = dependElements.map((d) => d.value);
     if (showIf) {
-      this.$node.classed('hidden', !this.desc.showIf(values));
+      this.node.classList.toggle('hidden', !this.desc.showIf(values));
     }
     return values;
   }

--- a/src/form/internal/Form.ts
+++ b/src/form/internal/Form.ts
@@ -2,7 +2,6 @@
  * Created by Samuel Gratzl on 08.03.2017.
  */
 
-import * as d3 from 'd3';
 import {randomId} from 'phovea_core/src/index';
 import {IFormElement, IForm, IFormElementDesc} from '../interfaces';
 
@@ -36,7 +35,7 @@ export class Form implements IForm {
   /**
    * DOM node for the form itself
    */
-  readonly $node: d3.Selection<any>;
+  readonly node: HTMLElement;
 
   /**
    * Map of all appended form elements with the element id as key
@@ -45,11 +44,13 @@ export class Form implements IForm {
 
   /**
    * Constructor
-   * @param $parent Node that the form should be attached to
+   * @param parentElement Node that the form should be attached to
    * @param formId unique form id
    */
-  constructor($parent: d3.Selection<any>, private readonly formId = randomId()) {
-    this.$node = $parent.append('form').attr('id', this.formId);
+  constructor(parentElement: HTMLElement, private readonly formId = randomId()) {
+    this.node = parentElement.ownerDocument.createElement('form');
+    this.node.setAttribute('id', this.formId);
+    parentElement.appendChild(this.node);
   }
 
   /**

--- a/src/form/internal/FormButton.ts
+++ b/src/form/internal/FormButton.ts
@@ -1,5 +1,4 @@
 import {FormElementType, IFormElement, IFormElementDesc, IForm} from '../interfaces';
-import * as d3 from 'd3';
 import {EventHandler} from 'phovea_core/src/event';
 
 export interface IButtonElementDesc extends IFormElementDesc {
@@ -8,17 +7,19 @@ export interface IButtonElementDesc extends IFormElementDesc {
 }
 
 export default class FormButton extends EventHandler implements IFormElement {
-  private $button: d3.Selection<HTMLButtonElement>;
-  private $node: d3.Selection<any>;
+  private button: HTMLElement;
+  private node: HTMLElement;
   private clicked: boolean = false;
 
   readonly type: FormElementType.BUTTON;
   readonly id: string;
 
-  constructor(readonly parent: IForm, readonly $parent, readonly desc: IButtonElementDesc) {
+  constructor(readonly parent: IForm, readonly parentElement: HTMLElement, readonly desc: IButtonElementDesc) {
     super();
     this.id = desc.id;
-    this.$node = $parent.append('div').classed('form-group', true);
+    this.node = parentElement.ownerDocument.createElement('div');
+    this.node.classList.add('form-group');
+    parentElement.appendChild(this.node);
     this.build();
   }
 
@@ -27,7 +28,7 @@ export default class FormButton extends EventHandler implements IFormElement {
    * @param visible
    */
   setVisible(visible: boolean) {
-    this.$node.classed('hidden', !visible);
+    this.node.classList.toggle('hidden', !visible);
   }
 
   get value(): boolean {
@@ -43,21 +44,23 @@ export default class FormButton extends EventHandler implements IFormElement {
   }
 
   protected build() {
-    this.$button = this.$node.append('button').classed(this.desc.attributes.clazz, true);
-    this.$button.html(() => this.desc.iconClass? `<i class="${this.desc.iconClass}"></i> ${this.desc.label}` : this.desc.label);
+    this.button = this.node.ownerDocument.createElement('button');
+    this.button.classList.toggle(this.desc.attributes.clazz, true);
+    this.button.innerHTML = this.desc.iconClass? `<i class="${this.desc.iconClass}"></i> ${this.desc.label}` : this.desc.label;
+    this.node.appendChild(this.button);
   }
 
   initialize() {
-    this.$button.on('click', () => {
+    this.button.addEventListener('click', (event) => {
       this.value = true;
       this.desc.onClick();
-      (<Event>d3.event).preventDefault();
-      (<Event>d3.event).stopPropagation();
+      event.preventDefault();
+      event.stopPropagation();
     });
     // TODO doesn't support show if
   }
 
   focus() {
-    (<HTMLButtonElement>this.$button.node()).focus();
+    this.button.focus();
   }
 }

--- a/src/form/internal/FormCheckBox.ts
+++ b/src/form/internal/FormCheckBox.ts
@@ -1,5 +1,4 @@
 import {IFormElementDesc, IForm} from '../interfaces';
-import * as d3 from 'd3';
 import {AFormElement} from './AFormElement';
 
 export interface ICheckBoxElementDesc extends IFormElementDesc {
@@ -21,18 +20,20 @@ export interface ICheckBoxElementDesc extends IFormElementDesc {
 
 export default class FormCheckBox extends AFormElement<ICheckBoxElementDesc> {
 
-  private $input: d3.Selection<any>;
+  private inputElement: HTMLInputElement;
 
   /**
    * Constructor
    * @param form
-   * @param $parent
+   * @param parentElement
    * @param desc
    */
-  constructor(form: IForm, $parent: d3.Selection<any>, desc: ICheckBoxElementDesc) {
+  constructor(form: IForm, parentElement: HTMLElement, desc: ICheckBoxElementDesc) {
     super(form, Object.assign({options: { checked: true, unchecked: false}}, desc));
 
-    this.$node = $parent.append('div').classed('checkbox', true);
+    this.node = parentElement.ownerDocument.createElement('div');
+    this.node.classList.add('checkbox');
+    parentElement.appendChild(this.node);
 
     this.build();
   }
@@ -42,14 +43,17 @@ export default class FormCheckBox extends AFormElement<ICheckBoxElementDesc> {
    */
   protected build() {
     super.build();
-    const $label = this.$node.select('label');
-    if ($label.empty()) {
-      this.$input = this.$node.append('input').attr('type', 'checkbox');
+    const label = this.node.querySelector('label');
+    if (label) {
+      label.innerHTML = `<input type="checkbox">${label.innerText}`;
+      this.inputElement = label.querySelector('input');
     } else {
-      this.$input = $label.html(`<input type="checkbox">${$label.text()}`).select('input');
+      this.inputElement = this.node.ownerDocument.createElement('input');
+      this.inputElement.setAttribute('type', 'checkbox');
+      this.node.appendChild(this.inputElement);
     }
-    this.setAttributes(this.$input, this.desc.attributes);
-    this.$input.classed('form-control', false); //remove falsy class again
+    this.setAttributes(this.inputElement, this.desc.attributes);
+    this.inputElement.classList.remove('form-control'); // remove falsy class again
   }
 
   /**
@@ -61,7 +65,7 @@ export default class FormCheckBox extends AFormElement<ICheckBoxElementDesc> {
     const options = this.desc.options;
     const isChecked: boolean = options.isChecked != null? options.isChecked : this.getStoredValue(options.unchecked) === options.checked;
     this.previousValue = isChecked;
-    this.$input.property('checked', isChecked);
+    this.inputElement.checked = isChecked;
     if (this.hasStoredValue()) { // trigger if we have a stored value
       // TODO: using the new value `isChecked` may be wrong, because it's of type boolean and options.checked and options.unchecked could be anything --> this.getStoredValue(...) should probably be used instead
       this.fire(FormCheckBox.EVENT_INITIAL_VALUE, isChecked, options.unchecked); // store initial values as actions with results in the provenance graph
@@ -70,8 +74,8 @@ export default class FormCheckBox extends AFormElement<ICheckBoxElementDesc> {
     this.handleDependent();
 
     // propagate change action with the data of the selected option
-    this.$input.on('change.propagate', () => {
-      this.fire(FormCheckBox.EVENT_CHANGE, this.value, this.$input);
+    this.inputElement.addEventListener('change.propagate', () => {
+      this.fire(FormCheckBox.EVENT_CHANGE, this.value, this.inputElement);
     });
   }
 
@@ -81,7 +85,7 @@ export default class FormCheckBox extends AFormElement<ICheckBoxElementDesc> {
    */
   get value() {
     const options = this.desc.options;
-    return this.$input.property('checked') ? options.checked : options.unchecked;
+    return this.inputElement.checked ? options.checked : options.unchecked;
   }
 
   /**
@@ -90,12 +94,12 @@ export default class FormCheckBox extends AFormElement<ICheckBoxElementDesc> {
    */
   set value(v: any) {
     const options = this.desc.options;
-    this.$input.property('value', v === options.checked);
+    this.inputElement.value = (v === options.checked).toString();
     this.previousValue = v === options.checked; // force old value change
     this.updateStoredValue();
   }
 
   focus() {
-    (<HTMLInputElement>this.$input.node()).focus();
+    this.inputElement.focus();
   }
 }

--- a/src/form/internal/FormInputText.ts
+++ b/src/form/internal/FormInputText.ts
@@ -2,7 +2,6 @@
  * Created by Samuel Gratzl on 08.03.2017.
  */
 
-import * as d3 from 'd3';
 import AFormElement from './AFormElement';
 import {IFormElementDesc, IForm} from '../interfaces';
 
@@ -25,18 +24,20 @@ export interface IFormInputTextDesc extends IFormElementDesc {
 
 export default class FormInputText extends AFormElement<IFormInputTextDesc> {
 
-  private $input: d3.Selection<any>;
+  private input: HTMLInputElement;
 
   /**
    * Constructor
    * @param form
-   * @param $parent
+   * @param parentElement
    * @param desc
    */
-  constructor(form: IForm, $parent: d3.Selection<any>, desc: IFormInputTextDesc) {
+  constructor(form: IForm, parentElement: HTMLElement, desc: IFormInputTextDesc) {
     super(form, desc);
 
-    this.$node = $parent.append('div').classed('form-group', true);
+    this.node = parentElement.ownerDocument.createElement('div');
+    this.node.classList.add('form-group');
+    parentElement.appendChild(this.node);
 
     this.build();
   }
@@ -46,8 +47,12 @@ export default class FormInputText extends AFormElement<IFormInputTextDesc> {
    */
   protected build() {
     super.build();
-    this.$input = this.$node.append('input').attr('type', (this.desc.options || {}).type || 'text');
-    this.setAttributes(this.$input, this.desc.attributes);
+
+    this.input = this.node.ownerDocument.createElement('input');
+    this.input.setAttribute('type', (this.desc.options || {}).type || 'text');
+    this.node.appendChild(this.input);
+
+    this.setAttributes(this.input, this.desc.attributes);
   }
 
   /**
@@ -59,7 +64,7 @@ export default class FormInputText extends AFormElement<IFormInputTextDesc> {
     const defaultValue = (this.desc.options || {}).type === 'number' ? '0' : '';
     const defaultText = this.getStoredValue(defaultValue);
     this.previousValue = defaultText;
-    this.$input.property('value', defaultText);
+    this.input.value = defaultText;
     if (this.hasStoredValue()) {
       this.fire(FormInputText.EVENT_INITIAL_VALUE, defaultText, defaultValue);
     }
@@ -67,8 +72,8 @@ export default class FormInputText extends AFormElement<IFormInputTextDesc> {
     this.handleDependent();
 
     // propagate change action with the data of the selected option
-    this.$input.on('change.propagate', () => {
-      this.fire(FormInputText.EVENT_CHANGE, this.value, this.$input);
+    this.input.addEventListener('change.propagate', () => {
+      this.fire(FormInputText.EVENT_CHANGE, this.value, this.input);
     });
   }
 
@@ -77,7 +82,7 @@ export default class FormInputText extends AFormElement<IFormInputTextDesc> {
    * @returns {string}
    */
   get value() {
-    return this.$input.property('value');
+    return this.input.value;
   }
 
   /**
@@ -85,12 +90,12 @@ export default class FormInputText extends AFormElement<IFormInputTextDesc> {
    * @param v
    */
   set value(v: string) {
-    this.$input.property('value', v);
+    this.input.value = v;
     this.previousValue = v; // force old value change
     this.updateStoredValue();
   }
 
   focus() {
-    (<HTMLInputElement>this.$input.node()).focus();
+    this.input.focus();
   }
 }

--- a/src/form/internal/FormSelect2.ts
+++ b/src/form/internal/FormSelect2.ts
@@ -3,7 +3,6 @@
  */
 
 import 'select2';
-import * as d3 from 'd3';
 import * as $ from 'jquery';
 import {mixin} from 'phovea_core/src/index';
 import {api2absURL} from 'phovea_core/src/ajax';
@@ -73,7 +72,7 @@ export const DEFAULT_AJAX_OPTIONS = Object.assign({
  */
 export default class FormSelect2 extends AFormElement<IFormSelect2> {
 
-  private $select: d3.Selection<any>;
+  private selectElement: HTMLElement;
 
   private $jqSelect: JQuery;
 
@@ -86,14 +85,17 @@ export default class FormSelect2 extends AFormElement<IFormSelect2> {
   /**
    * Constructor
    * @param form
-   * @param $parent
+   * @param parentElement
    * @param desc
    * @param multiple
    */
-  constructor(form: IForm, $parent, desc: IFormSelect2, multiple: 'multiple'|'single' = 'single') {
+  constructor(form: IForm, parentElement: HTMLElement, desc: IFormSelect2, multiple: 'multiple'|'single' = 'single') {
     super(form, desc);
 
-    this.$node = $parent.append('div').classed('form-group', true);
+    this.node = parentElement.ownerDocument.createElement('div');
+    this.node.classList.add('form-group');
+    parentElement.appendChild(this.node);
+
     this.multiple = multiple === 'multiple';
 
     this.build();
@@ -105,9 +107,10 @@ export default class FormSelect2 extends AFormElement<IFormSelect2> {
   protected build() {
     super.build();
 
-    this.$select = this.$node.append('select');
-    this.setAttributes(this.$select, this.desc.attributes);
+    this.selectElement = this.node.ownerDocument.createElement('select');
+    this.node.appendChild(this.selectElement);
 
+    this.setAttributes(this.selectElement, this.desc.attributes);
   }
 
   /**
@@ -121,7 +124,7 @@ export default class FormSelect2 extends AFormElement<IFormSelect2> {
     });
     const df = this.desc.options.data;
     const data = Array.isArray(df) ? df : (typeof df === 'function' ? df(values) : undefined);
-    this.buildSelect2(this.$select, this.desc.options || {}, data);
+    this.buildSelect2(this.selectElement, this.desc.options || {}, data);
 
 
     // propagate change action with the data of the selected option
@@ -131,7 +134,7 @@ export default class FormSelect2 extends AFormElement<IFormSelect2> {
   /**
    * Builds the jQuery select2
    */
-  private buildSelect2($select: d3.Selection<any>, options: IFormSelect2Options, data?: ISelect2Option[]) {
+  private buildSelect2(selectElement: HTMLElement, options: IFormSelect2Options, data?: ISelect2Option[]) {
     const select2Options: Select2Options = {};
 
     let initialValue: string[] = [];
@@ -158,7 +161,7 @@ export default class FormSelect2 extends AFormElement<IFormSelect2> {
     }
     mixin(select2Options, options.ajax ? DEFAULT_AJAX_OPTIONS : DEFAULT_OPTIONS, options, { data });
 
-    this.$jqSelect = (<any>$($select.node())).select2(select2Options).val(initialValue).trigger('change');
+    this.$jqSelect = (<any>$(selectElement)).select2(select2Options).val(initialValue).trigger('change');
     // force the old value from initial
     this.previousValue = this.resolveValue(this.$jqSelect.select2('data'));
 

--- a/src/form/internal/FormSelect3.ts
+++ b/src/form/internal/FormSelect3.ts
@@ -36,14 +36,17 @@ export default class FormSelect3 extends AFormElement<IFormSelect3> {
   /**
    * Constructor
    * @param form
-   * @param $parent
+   * @param parentElement
    * @param desc
    * @param multiple
    */
-  constructor(form: IForm, $parent, desc: IFormSelect3, multiple: 'multiple' | 'single' = 'single') {
+  constructor(form: IForm, parentElement: HTMLElement, desc: IFormSelect3, multiple: 'multiple' | 'single' = 'single') {
     super(form, desc);
 
-    this.$node = $parent.append('div').classed('form-group', true);
+    this.node = parentElement.ownerDocument.createElement('div');
+    this.node.classList.add('form-group');
+    parentElement.appendChild(this.node);
+
     this.multiple = multiple === 'multiple';
 
     this.build();
@@ -57,10 +60,10 @@ export default class FormSelect3 extends AFormElement<IFormSelect3> {
 
     const options = Object.assign(this.desc.options, {multiple: this.multiple});
     this.select3 = new Select3(options);
-    this.$node.node().appendChild(this.select3.node);
+    this.node.appendChild(this.select3.node);
 
     this.desc.attributes.clazz = this.desc.attributes.clazz.replace('form-control', ''); // filter out the form-control class, because the border it creates doesn't contain the whole element due to absolute positioning and it isn't necessary
-    this.setAttributes(this.$node.select('.select3'), this.desc.attributes);
+    this.setAttributes(this.node.querySelector('.select3'), this.desc.attributes);
 
   }
 

--- a/src/form/internal/index.ts
+++ b/src/form/internal/index.ts
@@ -10,10 +10,10 @@ import {FORM_EXTENSION_POINT} from '..';
  * An element is found when `desc.type` is matching the extension id.
  *
  * @param form the form to which the element will be appended
- * @param $parent parent D3 selection element
+ * @param parentElement parent DOM element
  * @param desc form element description
  */
-export function create(form: IForm, $parent: d3.Selection<any>, desc: IFormElementDesc): Promise<IFormElement> {
+export function create(form: IForm, parentElement: HTMLElement, desc: IFormElementDesc): Promise<IFormElement> {
   const plugins = list((pluginDesc: IPluginDesc) => {
     return pluginDesc.type === FORM_EXTENSION_POINT && pluginDesc.id === desc.type;
   });
@@ -23,8 +23,8 @@ export function create(form: IForm, $parent: d3.Selection<any>, desc: IFormEleme
   return plugins[0].load().then((p) => {
     // selection is used in SELECT2 and SELECT3
     if(p.desc.selection) {
-      return p.factory(form, $parent, <any>desc, p.desc.selection);
+      return p.factory(form, parentElement, <any>desc, p.desc.selection);
     }
-    return p.factory(form, $parent, <any>desc);
+    return p.factory(form, parentElement, <any>desc);
   });
 }

--- a/src/views/AView.ts
+++ b/src/views/AView.ts
@@ -2,7 +2,6 @@
  * Created by Samuel Gratzl on 29.01.2016.
  */
 
-import {select} from 'd3';
 import {EventHandler} from 'phovea_core/src/event';
 import {defaultSelectionType, IDType, resolve} from 'phovea_core/src/idtype';
 import {none} from 'phovea_core/src/range';
@@ -110,7 +109,7 @@ export abstract class AView extends EventHandler implements IView {
   }
 
   private buildParameterForm(params: HTMLElement, onParameterChange: (name: string, value: any, previousValue: any) => Promise<any>): Promise<IForm> {
-    const builder = new FormBuilder(select(params));
+    const builder = new FormBuilder(params);
 
     //work on a local copy since we change it by adding an onChange handler
     const descs = this.getParameterFormDescs().map((d) => Object.assign({}, d));


### PR DESCRIPTION
Part of #19

_FormRadio_ and _FormSelect_ are the only classes left that use a D3 data join.

![grafik](https://user-images.githubusercontent.com/5851088/62658283-ba9b7b80-b968-11e9-9e77-302a7e9e008b.png)

Overall there are more classes using D3 modules:

![grafik](https://user-images.githubusercontent.com/5851088/62658374-f1719180-b968-11e9-85ab-99d88aa8cebc.png)
