### PR TITLE
Optional security

### DIFF
--- a/src/views/findViews.ts
+++ b/src/views/findViews.ts
@@ -16,7 +16,7 @@ import {
 } from '../extensions';
 import {IPluginDesc, list as listPlugins} from 'phovea_core/src/plugin';
 import Range from 'phovea_core/src/range/Range';
-import {currentUser} from 'phovea_core/src/security';
+import {currentUser, isLoggedIn} from 'phovea_core/src/security';
 import {resolveImmediately} from 'phovea_core/src';
 
 export interface IDiscoveredView {
@@ -111,7 +111,10 @@ export function canAccess(p: any) {
     return security(user);
   }
   if (typeof security === 'boolean') {
-    return security === false; // check if security is disabled
+    if (security === true) { // if security is set on a view with a boolean flag check if the user is at least logged in
+      return isLoggedIn();
+    }
+    return true; // security is disabled - the resource is publicly available, the user can access it
   }
   return true;
 }

--- a/src/views/findViews.ts
+++ b/src/views/findViews.ts
@@ -110,6 +110,9 @@ export function canAccess(p: any) {
     }
     return security(user);
   }
+  if (typeof security === 'boolean') {
+    return security === false; // check if security is disabled
+  }
   return true;
 }
 

--- a/tdp_core/db.py
+++ b/tdp_core/db.py
@@ -49,7 +49,7 @@ def resolve_engine(database):
   return configs.engine(database)
 
 
-def resolve_view(database, view_name, check_default_security = False):
+def resolve_view(database, view_name, check_default_security=False):
   """
   finds and return the connector, engine, and view for the given database and view_name
   :param database: database key to lookup

--- a/tdp_core/db.py
+++ b/tdp_core/db.py
@@ -54,6 +54,7 @@ def resolve_view(database, view_name, check_default_security=False):
   finds and return the connector, engine, and view for the given database and view_name
   :param database: database key to lookup
   :param view_name: view name to lookup
+  :param check_default_security: bool; usually view.can_access returns True when no security is defined on the view. This parameter can be used to tell the method that it should check the security anyway, e.g. that the user is at least logged in
   :return: (connector, engine, view)
   """
   connector, engine = resolve(database)

--- a/tdp_core/db.py
+++ b/tdp_core/db.py
@@ -49,7 +49,7 @@ def resolve_engine(database):
   return configs.engine(database)
 
 
-def resolve_view(database, view_name):
+def resolve_view(database, view_name, check_default_security = False):
   """
   finds and return the connector, engine, and view for the given database and view_name
   :param database: database key to lookup
@@ -60,7 +60,8 @@ def resolve_view(database, view_name):
   if view_name not in connector.views:
     abort(404, u'view with id "{}" cannot be found in database "{}"'.format(view_name, database))
   view = connector.views[view_name]
-  if not view.can_access():
+  # TODO: improve the logic of the view.can_access function, because even for unauthorized can_access returns True, i.e. that the user can access the resource. Somewhere else the server checks whether the user is authenticated or not
+  if not view.can_access(check_default_security):
     abort(403)
   return connector, engine, view
 

--- a/tdp_core/dbview.py
+++ b/tdp_core/dbview.py
@@ -43,7 +43,7 @@ class DBView(object):
     self.argument_infos = {}
     self.filters = {}
     self.table = None
-    self.security = None
+    self.security = True
     self.assign_ids = False
 
   def needs_to_fill_up_columns(self):
@@ -133,6 +133,8 @@ class DBView(object):
       return True
     if callable(self.security):
       return self.security(current_user())
+    if isinstance(self.security, bool) and self.security is False: # check if security is a boolean and if it's disabled, i.e. it's value is False
+      return True # return that we're allowed to access the view, because its security is disabled
     role = unicode(self.security)
     return current_user().has_role(role)
 

--- a/tdp_core/dbview.py
+++ b/tdp_core/dbview.py
@@ -133,8 +133,8 @@ class DBView(object):
       return True
     if callable(self.security):
       return self.security(current_user())
-    if isinstance(self.security, bool) and self.security is False: # check if security is a boolean and if it's disabled, i.e. it's value is False
-      return True # return that we're allowed to access the view, because its security is disabled
+    if isinstance(self.security, bool) and self.security is False:  # check if security is a boolean and if it's disabled, i.e. it's value is False
+      return True  # return that we're allowed to access the view, because its security is disabled
     role = unicode(self.security)
     return current_user().has_role(role)
 

--- a/tdp_core/dbview.py
+++ b/tdp_core/dbview.py
@@ -129,7 +129,7 @@ class DBView(object):
     return self.argument_infos.get(key)
 
   # TODO: improve the logic of this function, because even for unauthorized can_access returns True, i.e. that the user can access the resource. Somewhere else the server checks whether the user is authenticated or not
-  def can_access(self, check_default_security = False):
+  def can_access(self, check_default_security=False):
     """
     check whether a user can access a DBView (DBView.security is checked and can either be a boolean, a string (=group the user must belong to) or a function) or not.
     :param check_default_security: bool; True if the security should be checked by default, otherwise it is False (default = False)

--- a/tdp_core/dbview.py
+++ b/tdp_core/dbview.py
@@ -43,7 +43,7 @@ class DBView(object):
     self.argument_infos = {}
     self.filters = {}
     self.table = None
-    self.security = True
+    self.security = None
     self.assign_ids = False
 
   def needs_to_fill_up_columns(self):
@@ -128,7 +128,15 @@ class DBView(object):
   def get_argument_info(self, key):
     return self.argument_infos.get(key)
 
-  def can_access(self):
+  # TODO: improve the logic of this function, because even for unauthorized can_access returns True, i.e. that the user can access the resource. Somewhere else the server checks whether the user is authenticated or not
+  def can_access(self, check_default_security = False):
+    """
+    check whether a user can access a DBView (DBView.security is checked and can either be a boolean, a string (=group the user must belong to) or a function) or not.
+    :param check_default_security: bool; True if the security should be checked by default, otherwise it is False (default = False)
+    :return: bool
+    """
+    if self.security is None and check_default_security is False:
+      return True
     if isinstance(self.security, str):
       role = unicode(self.security)
       return current_user().has_role(role)

--- a/tdp_core/dbview.py
+++ b/tdp_core/dbview.py
@@ -132,7 +132,7 @@ class DBView(object):
   def can_access(self, check_default_security=False):
     """
     check whether a user can access a DBView (DBView.security is checked and can either be a boolean, a string (=group the user must belong to) or a function) or not.
-    :param check_default_security: bool; True if the security should be checked by default, otherwise it is False (default = False)
+    :param check_default_security: bool (default = False); True if the security should be checked by default, e.g. although self.security is None, otherwise the function will return True
     :return: bool
     """
     if self.security is None and check_default_security is False:

--- a/tdp_core/dbview.py
+++ b/tdp_core/dbview.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from collections import OrderedDict
-from phovea_server.security import current_user
+from phovea_server.security import current_user, is_logged_in
 from .utils import clean_query
 
 __author__ = 'Samuel Gratzl'
@@ -129,14 +129,14 @@ class DBView(object):
     return self.argument_infos.get(key)
 
   def can_access(self):
-    if self.security is None:
-      return True
+    if isinstance(self.security, str):
+      role = unicode(self.security)
+      return current_user().has_role(role)
     if callable(self.security):
       return self.security(current_user())
     if isinstance(self.security, bool) and self.security is False:  # check if security is a boolean and if it's disabled, i.e. it's value is False
       return True  # return that we're allowed to access the view, because its security is disabled
-    role = unicode(self.security)
-    return current_user().has_role(role)
+    return is_logged_in()  # because security is not disabled check if the user is at least logged in
 
 
 class DBViewBuilder(object):

--- a/tdp_core/formatter.py
+++ b/tdp_core/formatter.py
@@ -1,0 +1,29 @@
+from phovea_server.ns import request, Response
+from phovea_server.util import jsonify
+
+def _format_csv(array_of_dicts):
+  import pandas as pd
+  import io
+
+  if not array_of_dicts:
+    return Response('', mimetype='text/csv')
+
+  out = io.BytesIO()
+  d = pd.DataFrame.from_records(array_of_dicts)
+  d.to_csv(out, sep='\t', encoding='utf-8', index=False)
+  return Response(out.getvalue(), mimetype='text/csv')
+
+
+def _format_json_decimal(obj):
+  return jsonify(obj, double_precision=15)
+
+def formatter(view_name):
+  if view_name.endswith('.csv'):
+    return view_name[:-4], _format_csv
+  elif request.values.get('_format') == 'csv':
+    return view_name, _format_csv
+  elif view_name.endswith('.json'):
+    return view_name[:-5], _format_json_decimal
+  elif request.values.get('_format') == 'json':
+    return view_name, _format_json_decimal
+  return view_name, jsonify

--- a/tdp_core/formatter.py
+++ b/tdp_core/formatter.py
@@ -1,6 +1,7 @@
 from phovea_server.ns import request, Response
 from phovea_server.util import jsonify
 
+
 def _format_csv(array_of_dicts):
   import pandas as pd
   import io
@@ -16,6 +17,7 @@ def _format_csv(array_of_dicts):
 
 def _format_json_decimal(obj):
   return jsonify(obj, double_precision=15)
+
 
 def formatter(view_name):
   if view_name.endswith('.csv'):

--- a/tdp_core/security.py
+++ b/tdp_core/security.py
@@ -8,7 +8,7 @@ from functools import wraps
 def tdp_login_required(func):
   @wraps(func)
   def decorated_view(*args, **kwargs):
-    if kwargs['view_name'] is not None and kwargs['database'] is not None:
+    if kwargs.get('view_name', None) is not None and kwargs.get('database', None) is not None:
       view_name, _ = formatter(kwargs['view_name'])
       config, _, view = resolve_view(kwargs['database'], view_name)
       if isinstance(view.security, bool) and view.security is False:  # if security is disabled for the view just call it without checking the login

--- a/tdp_core/security.py
+++ b/tdp_core/security.py
@@ -2,13 +2,14 @@ from phovea_server.security import login_required
 from .formatter import formatter
 from .db import resolve_view
 
+
 # custom login_required decorator to be able to disable the login for DBViews, i.e. to make them public
 def tdp_login_required(func):
   def decorated_view(*args, **kwargs):
     if kwargs['view_name'] is not None and kwargs['database'] is not None:
       view_name, _ = formatter(kwargs['view_name'])
       config, _, view = resolve_view(kwargs['database'], view_name)
-      if isinstance(view.security, bool) and view.security is False: # if security is disabled for the view just call it without checking the login
+      if isinstance(view.security, bool) and view.security is False:  # if security is disabled for the view just call it without checking the login
         return func(*args, **kwargs)
       # check the login if security was not disabled
       return login_required(func)

--- a/tdp_core/security.py
+++ b/tdp_core/security.py
@@ -14,4 +14,7 @@ def tdp_login_required(func):
       return login_required(func)
 
     return login_required(func)
+
+  # override the name of the decorated view, otherwise we get an internal server error when we use the decorator more than once
+  decorated_view.__name__ = func.__name__
   return decorated_view

--- a/tdp_core/security.py
+++ b/tdp_core/security.py
@@ -1,0 +1,17 @@
+from phovea_server.security import login_required
+from .formatter import formatter
+from .db import resolve_view
+
+# custom login_required decorator to be able to disable the login for DBViews, i.e. to make them public
+def tdp_login_required(func):
+  def decorated_view(*args, **kwargs):
+    if kwargs['view_name'] is not None and kwargs['database'] is not None:
+      view_name, _ = formatter(kwargs['view_name'])
+      config, _, view = resolve_view(kwargs['database'], view_name)
+      if isinstance(view.security, bool) and view.security is False: # if security is disabled for the view just call it without checking the login
+        return func(*args, **kwargs)
+      # check the login if security was not disabled
+      return login_required(func)
+
+    return login_required(func)
+  return decorated_view

--- a/tdp_core/security.py
+++ b/tdp_core/security.py
@@ -11,10 +11,8 @@ def tdp_login_required(func):
       config, _, view = resolve_view(kwargs['database'], view_name)
       if isinstance(view.security, bool) and view.security is False:  # if security is disabled for the view just call it without checking the login
         return func(*args, **kwargs)
-      # check the login if security was not disabled
-      return login_required(func)
-
-    return login_required(func)
+      return login_required(func)(*args, **kwargs)  # call the function returned by the decorator
+    return login_required(func)(*args, **kwargs)
 
   # override the name of the decorated view, otherwise we get an internal server error when we use the decorator more than once
   decorated_view.__name__ = func.__name__

--- a/tdp_core/security.py
+++ b/tdp_core/security.py
@@ -1,10 +1,12 @@
 from phovea_server.security import login_required
 from .formatter import formatter
 from .db import resolve_view
+from functools import wraps
 
 
 # custom login_required decorator to be able to disable the login for DBViews, i.e. to make them public
 def tdp_login_required(func):
+  @wraps(func)
   def decorated_view(*args, **kwargs):
     if kwargs['view_name'] is not None and kwargs['database'] is not None:
       view_name, _ = formatter(kwargs['view_name'])
@@ -14,6 +16,4 @@ def tdp_login_required(func):
       return login_required(func)(*args, **kwargs)  # call the function returned by the decorator
     return login_required(func)(*args, **kwargs)
 
-  # override the name of the decorated view, otherwise we get an internal server error when we use the decorator more than once
-  decorated_view.__name__ = func.__name__
   return decorated_view

--- a/tdp_core/sql.py
+++ b/tdp_core/sql.py
@@ -2,7 +2,6 @@ from phovea_server.ns import Namespace, request, abort
 from . import db
 from .utils import map_scores
 from phovea_server.util import jsonify
-from phovea_server.security import login_required
 from .security import tdp_login_required
 from .formatter import formatter
 import logging
@@ -26,7 +25,7 @@ def list_database():
 
 
 @app.route('/<database>/')
-@login_required
+@tdp_login_required
 def list_view(database):
   config_engine = db.resolve(database)
   if not config_engine:

--- a/tdp_core/sql.py
+++ b/tdp_core/sql.py
@@ -3,7 +3,10 @@ from . import db
 from .utils import map_scores
 from phovea_server.util import jsonify
 from phovea_server.security import login_required
+from .security import tdp_login_required
+from .formatter import formatter
 import logging
+
 
 __author__ = 'Samuel Gratzl'
 _log = logging.getLogger(__name__)
@@ -45,35 +48,6 @@ def _return_query():
   return not v or v.lower()[0] != 'f'
 
 
-def _format_csv(array_of_dicts):
-  import pandas as pd
-  import io
-
-  if not array_of_dicts:
-    return Response('', mimetype='text/csv')
-
-  out = io.BytesIO()
-  d = pd.DataFrame.from_records(array_of_dicts)
-  d.to_csv(out, sep='\t', encoding='utf-8', index=False)
-  return Response(out.getvalue(), mimetype='text/csv')
-
-
-def _format_json_decimal(obj):
-  return jsonify(obj, double_precision=15)
-
-
-def _formatter(view_name):
-  if view_name.endswith('.csv'):
-    return view_name[:-4], _format_csv
-  elif request.values.get('_format') == 'csv':
-    return view_name, _format_csv
-  elif view_name.endswith('.json'):
-    return view_name[:-5], _format_json_decimal
-  elif request.values.get('_format') == 'json':
-    return view_name, _format_json_decimal
-  return view_name, jsonify
-
-
 @app.route('/<database>/<view_name>', methods=['GET', 'POST'])
 @app.route('/<database>/<view_name>/filter', methods=['GET', 'POST'])
 @login_required
@@ -84,7 +58,7 @@ def get_filtered_data(database, view_name):
   :param view_name:
   :return:
   """
-  view_name, format = _formatter(view_name)
+  view_name, format = formatter(view_name)
   if _return_query():
     return jsonify(db.get_filtered_query(database, view_name, request.values))
 
@@ -96,7 +70,7 @@ def get_filtered_data(database, view_name):
 
 
 @app.route('/<database>/<view_name>/score', methods=['GET', 'POST'])
-@login_required
+@tdp_login_required
 def get_score_data(database, view_name):
   """
   version of getting data like filter with additional mapping of score entries
@@ -104,7 +78,7 @@ def get_score_data(database, view_name):
   :param view_name:
   :return:
   """
-  view_name, format = _formatter(view_name)
+  view_name, format = formatter(view_name)
   if _return_query():
     return jsonify(db.get_filtered_query(database, view_name, request.values))
 
@@ -132,7 +106,7 @@ def get_count_data(database, view_name):
   :param view_name:
   :return:
   """
-  view_name, _ = _formatter(view_name)
+  view_name, _ = formatter(view_name)
   if _return_query():
     return jsonify(db.get_count_query(database, view_name, request.values))
 
@@ -144,7 +118,7 @@ def get_count_data(database, view_name):
 @app.route('/<database>/<view_name>/desc')
 @login_required
 def get_desc(database, view_name):
-  view_name, _ = _formatter(view_name)
+  view_name, _ = formatter(view_name)
   config, _, view = db.resolve_view(database, view_name)
   return jsonify(dict(idType=view.idtype, columns=view.columns.values()))
 
@@ -156,7 +130,7 @@ def lookup(database, view_name):
   Does the same job as search, but paginates the result set
   This function is used in conjunction with Select2 form elements
   """
-  view_name, _ = _formatter(view_name)
+  view_name, _ = formatter(view_name)
   query = request.values.get('query', '').lower()
   page = int(request.values.get('page', 0))  # zero based
   limit = int(request.values.get('limit', 30))  # or 'all'

--- a/tdp_core/sql.py
+++ b/tdp_core/sql.py
@@ -2,7 +2,6 @@ from phovea_server.ns import Namespace, request, abort, Response
 from . import db
 from .utils import map_scores
 from phovea_server.util import jsonify
-from phovea_server.security import login_required
 from .security import tdp_login_required
 from .formatter import formatter
 import logging
@@ -21,13 +20,13 @@ def load_ids(idtype, mapping):
 
 
 @app.route('/')
-@login_required
+@tdp_login_required
 def list_database():
   return jsonify([v.dump(k) for k, v in db.configs.connectors.items()])
 
 
 @app.route('/<database>/')
-@login_required
+@tdp_login_required
 def list_view(database):
   config_engine = db.resolve(database)
   if not config_engine:
@@ -50,7 +49,7 @@ def _return_query():
 
 @app.route('/<database>/<view_name>', methods=['GET', 'POST'])
 @app.route('/<database>/<view_name>/filter', methods=['GET', 'POST'])
-@login_required
+@tdp_login_required
 def get_filtered_data(database, view_name):
   """
   version of getting data in which the arguments starting with `filter_` are used to build a where clause
@@ -98,7 +97,7 @@ def get_score_data(database, view_name):
 
 
 @app.route('/<database>/<view_name>/count', methods=['GET', 'POST'])
-@login_required
+@tdp_login_required
 def get_count_data(database, view_name):
   """
   similar to the /filter clause but returns the count of results instead of the rows itself
@@ -116,7 +115,7 @@ def get_count_data(database, view_name):
 
 
 @app.route('/<database>/<view_name>/desc')
-@login_required
+@tdp_login_required
 def get_desc(database, view_name):
   view_name, _ = formatter(view_name)
   config, _, view = db.resolve_view(database, view_name)
@@ -124,7 +123,7 @@ def get_desc(database, view_name):
 
 
 @app.route('/<database>/<view_name>/lookup', methods=['GET', 'POST'])
-@login_required
+@tdp_login_required
 def lookup(database, view_name):
   """
   Does the same job as search, but paginates the result set

--- a/tdp_core/sql.py
+++ b/tdp_core/sql.py
@@ -2,10 +2,10 @@ from phovea_server.ns import Namespace, request, abort
 from . import db
 from .utils import map_scores
 from phovea_server.util import jsonify
+from phovea_server.security import login_required
 from .security import tdp_login_required
 from .formatter import formatter
 import logging
-
 
 __author__ = 'Samuel Gratzl'
 _log = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ def list_database():
 
 
 @app.route('/<database>/')
-@tdp_login_required
+@login_required
 def list_view(database):
   config_engine = db.resolve(database)
   if not config_engine:
@@ -57,7 +57,9 @@ def get_filtered_data(database, view_name):
   :param view_name:
   :return:
   """
+
   view_name, format = formatter(view_name)
+
   if _return_query():
     return jsonify(db.get_filtered_query(database, view_name, request.values))
 

--- a/tdp_core/sql.py
+++ b/tdp_core/sql.py
@@ -1,4 +1,4 @@
-from phovea_server.ns import Namespace, request, abort, Response
+from phovea_server.ns import Namespace, request, abort
 from . import db
 from .utils import map_scores
 from phovea_server.util import jsonify


### PR DESCRIPTION
this PR enables us to exclude specific views from the security mechanism, i.e. to have public routes without the need of being logged in.

the DBViewBuilder already supported the `.security` method, but now we can use Boolean values, such as
```
views['some_view'] = DBViewBuilder(')
    ...
    .security(False) \ # boolean value to disable security for this view
```

the generated route will be publicly available

I've tested this PR with Ordino by having one browser window where I'm logged in and one private window where I'm logged out.

Firstly in the browser window where I'm logged in:
- I've made one route public, e.g. the request where the gene_panel is queried
- Then I've computed scores with private routes (no security set on `DBView`s)
- And vice versa (private route for gene_panels and public routes for scores)

Secondly in the private browser tab (I've taken the HTTP request from the browser's dev tools, because otherwise you'll get the login screen):
- Send a request where the gene_panel (public) is queried
- Compute scores (private)
- And vice versa (private route for gene_panels and public routes for scores)

I've come to the following conclusion:

| route / logged in | true | false |
| --- | ---: | ---: |
| **private** | ✓ | ⨯ |
| **public** | ✓ | ✓ |

**Legend:** ✓ = successful HTTP request, ⨯ = 401 (Unauthorized)


I was not really sure how to test the frontend code, because in usual TDP applications the user has to be logged in to come to the point where detail views are queried anyway, but it should also work (if the security is disabled === false it returns true, otherwise it checks whether the user is logged in or not)

you can see the wiki documentation in the tutorial [How to create a DB Connector](https://wiki.datavisyn.io/tdp/tutorials/how-to-create-a-db-connector#security)