### PR TITLE
Simplify data download dialog

### DIFF
--- a/src/lineup/internal/LineUpPanelActions.ts
+++ b/src/lineup/internal/LineUpPanelActions.ts
@@ -214,19 +214,25 @@ export default class LineUpPanelActions extends EventHandler {
 
   private appendDownload() {
     const node = this.node.ownerDocument.createElement('div');
-    node.classList.add('btn-group');
+    node.classList.add('btn-group', 'download-data-dropdown');
     node.innerHTML = `
       <button type="button" class="dropdown-toggle fa fa-download" style="width: 100%;" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Download Data">
       </button>
       <ul class="dropdown-menu dropdown-menu-${this.isTopMode ? 'left' : 'right'}">
         <li class="dropdown-header">Download All Rows</li>
         <li><a href="#" data-s="a" data-t="xlsx">Microsoft Excel (xlsx)</a></li>
-        <li class="dropdown-header">Download Selected Rows Only</li>
+        <li class="dropdown-header" data-num-selected-rows="0">Download Selected Rows Only</li>
         <li><a href="#" data-s="s" data-t="xlsx">Microsoft Excel (xlsx)</a></li>
         <li role="separator" class="divider"></li>
         <li><a href="#" data-s="s" data-t="custom">Customize &hellip;</a></li>
       </ul>
     `;
+
+    // Listen for row selection and update number of selected rows
+    // Show/hide some dropdown menu points accordingly using CSS
+    this.provider.on(LocalDataProvider.EVENT_SELECTION_CHANGED + '.download-menu', (indices: number[]) => {
+      (<HTMLElement>node.querySelector('[data-num-selected-rows]')).dataset.numSelectedRows = indices.length.toString();
+    });
 
     const links = Array.from(node.querySelectorAll('a'));
     for (const link of links) {

--- a/src/lineup/internal/LineUpPanelActions.ts
+++ b/src/lineup/internal/LineUpPanelActions.ts
@@ -220,16 +220,8 @@ export default class LineUpPanelActions extends EventHandler {
       </button>
       <ul class="dropdown-menu dropdown-menu-${this.isTopMode ? 'left' : 'right'}">
         <li class="dropdown-header">Download All Rows</li>
-        <li><a href="#" data-s="a" data-t="csv">CSV (comma separated)</a></li>
-        <li><a href="#" data-s="a" data-t="tsv">TSV (tab separated)</a></li>
-        <li><a href="#" data-s="a" data-t="ssv">CSV (semicolon separated)</a></li>
-        <li><a href="#" data-s="a" data-t="json">JSON</a></li>
         <li><a href="#" data-s="a" data-t="xlsx">Microsoft Excel (xlsx)</a></li>
         <li class="dropdown-header">Download Selected Rows Only</li>
-        <li><a href="#" data-s="s" data-t="csv">CSV (comma separated)</a></li>
-        <li><a href="#" data-s="s" data-t="tsv">TSV (tab separated)</a></li>
-        <li><a href="#" data-s="a" data-t="ssv">CSV (semicolon separated)</a></li>
-        <li><a href="#" data-s="s" data-t="json">JSON</a></li>
         <li><a href="#" data-s="s" data-t="xlsx">Microsoft Excel (xlsx)</a></li>
         <li role="separator" class="divider"></li>
         <li><a href="#" data-s="s" data-t="custom">Customize &hellip;</a></li>

--- a/src/styles/_view_lineup.scss
+++ b/src/styles/_view_lineup.scss
@@ -207,7 +207,6 @@ $lu_assets: '~lineupjs/src/assets';
     }
 
     .download-data-dropdown {
-
       // show the number of selected rows after the element
       li[data-num-selected-rows]::after {
         content: ' (' attr(data-num-selected-rows) ')';

--- a/src/styles/_view_lineup.scss
+++ b/src/styles/_view_lineup.scss
@@ -213,6 +213,13 @@ $lu_assets: '~lineupjs/src/assets';
         content: ' (' attr(data-num-selected-rows) ')';
         display: inline;
       }
+
+      // hide the dropdown-header and the next list point (= download link), if no rows are selected
+      // note that this only works for a *single* link as after the header list item!
+      li[data-num-selected-rows='0'],
+      li[data-num-selected-rows='0'] + li {
+        display: none;
+      }
     }
 
     &.collapsed {

--- a/src/styles/_view_lineup.scss
+++ b/src/styles/_view_lineup.scss
@@ -206,6 +206,15 @@ $lu_assets: '~lineupjs/src/assets';
       }
     }
 
+    .download-data-dropdown {
+
+      // show the number of selected rows after the element
+      li[data-num-selected-rows]::after {
+        content: ' (' attr(data-num-selected-rows) ')';
+        display: inline;
+      }
+    }
+
     &.collapsed {
       max-width: 3em;
       min-width: 0;


### PR DESCRIPTION
Closes #199 

* Remove less used download options from drop down 
  Note: The different file types can still be selected from the _Customize..._ dialog
* Show number of selected rows in download drop-down 
* Show download option for selected rows only if rows are selected

**Before**

![grafik](https://user-images.githubusercontent.com/5851088/63863316-4f185d00-c9ae-11e9-8b16-ad084d4fffe5.png)

**After (no selected rows)**
![grafik](https://user-images.githubusercontent.com/5851088/63864250-d1ede780-c9af-11e9-87b1-f9479f45c6cd.png)

**After (selected rows)**
![grafik](https://user-images.githubusercontent.com/5851088/63864211-bf73ae00-c9af-11e9-8cff-7ee6bed2e58b.png)

