### PR TITLE
Annotate actionFunction extensions with tdp_matomo

### DIFF
--- a/src/phovea.ts
+++ b/src/phovea.ts
@@ -6,16 +6,26 @@
 import {IRegistry} from 'phovea_core/src/plugin';
 
 export default function (registry: IRegistry) {
-  function actionFunction(id: string, factory: string, loader: () => any) {
-    registry.push('actionFunction', id, loader, { factory });
+  function actionFunction(id: string, factory: string, loader: () => any, options?: {}) {
+    registry.push('actionFunction', id, loader, { factory, ...options });
   }
 
   function actionCompressor(id: string, factory: string, matches: string, loader: () => any) {
     registry.push('actionCompressor', id, loader, { factory, matches });
   }
 
-  actionFunction('tdpInitSession', 'initSessionImpl', () => System.import('./internal/cmds'));
-  actionFunction('tdpSetParameter', 'setParameterImpl', () => System.import('./internal/cmds'));
+  actionFunction('tdpInitSession', 'initSessionImpl', () => System.import('./internal/cmds'), {
+    tdp_matomo: {
+      category: 'session',
+      action: 'init'
+    }
+  });
+  actionFunction('tdpSetParameter', 'setParameterImpl', () => System.import('./internal/cmds'), {
+    tdp_matomo: {
+      category: 'view',
+      action: 'setParameter'
+    }
+  });
   actionCompressor('tdpCompressSetParameter', 'compressSetParameter', '(tdpSetParameter)', () => System.import('./internal/cmds'));
 
   // compatibility
@@ -24,8 +34,18 @@ export default function (registry: IRegistry) {
   actionCompressor('targidCompressSetParameter', 'compressSetParameterOld', '(targidSetParameter)', () => System.import('./internal/cmds'));
 
 
-  actionFunction('tdpAddScore', 'addScoreImpl', () => System.import('./lineup/internal/scorecmds'));
-  actionFunction('tdpRemoveScore', 'removeScoreImpl', () => System.import('./lineup/internal/scorecmds'));
+  actionFunction('tdpAddScore', 'addScoreImpl', () => System.import('./lineup/internal/scorecmds'), {
+    tdp_matomo: {
+      category: 'score',
+      action: 'add'
+    }
+  });
+  actionFunction('tdpRemoveScore', 'removeScoreImpl', () => System.import('./lineup/internal/scorecmds'), {
+    tdp_matomo: {
+      category: 'score',
+      action: 'remove'
+    }
+  });
   actionCompressor('tdpScoreCompressor', 'compress', '(tdpAddScore|tdpRemoveScore)', () => System.import('./lineup/internal/scorecmds'));
 
   // compatibility
@@ -33,11 +53,46 @@ export default function (registry: IRegistry) {
   actionFunction('ordinoRemoveScore', 'removeScoreImpl', () => System.import('./lineup/internal/scorecmds'));
   actionCompressor('ordinoScoreCompressor', 'compressComp', '(ordinoAddScore|ordinoRemoveScore)', () => System.import('./lineup/internal/scorecmds'));
 
-  actionFunction('lineupAddRanking', 'addRankingImpl', () => System.import('./lineup/internal/cmds'));
-  actionFunction('lineupSetRankingSortCriteria', 'setRankingSortCriteriaImpl', () => System.import('./lineup/internal/cmds'));
-  actionFunction('lineupSetSortCriteria', 'setSortCriteriaImpl', () => System.import('./lineup/internal/cmds'));
-  actionFunction('lineupSetGroupCriteria', 'setGroupCriteriaImpl', () => System.import('./lineup/internal/cmds'));
-  actionFunction('lineupSetColumn', 'setColumnImpl', () => System.import('./lineup/internal/cmds'));
-  actionFunction('lineupAddColumn', 'addColumnImpl', () => System.import('./lineup/internal/cmds'));
-  actionFunction('lineupMoveColumn', 'moveColumnImpl', () => System.import('./lineup/internal/cmds'));
+  actionFunction('lineupAddRanking', 'addRankingImpl', () => System.import('./lineup/internal/cmds'), {
+    tdp_matomo: {
+      category: 'lineup',
+      action: 'addRanking'
+    }
+  });
+  actionFunction('lineupSetRankingSortCriteria', 'setRankingSortCriteriaImpl', () => System.import('./lineup/internal/cmds'), {
+    tdp_matomo: {
+      category: 'lineup',
+      action: 'setRankingSortCriteria'
+    }
+  });
+  actionFunction('lineupSetSortCriteria', 'setSortCriteriaImpl', () => System.import('./lineup/internal/cmds'), {
+    tdp_matomo: {
+      category: 'lineup',
+      action: 'setSortCriteria'
+    }
+  });
+  actionFunction('lineupSetGroupCriteria', 'setGroupCriteriaImpl', () => System.import('./lineup/internal/cmds'), {
+    tdp_matomo: {
+      category: 'lineup',
+      action: 'setGroupCriteria'
+    }
+  });
+  actionFunction('lineupSetColumn', 'setColumnImpl', () => System.import('./lineup/internal/cmds'), {
+    tdp_matomo: {
+      category: 'lineup',
+      action: 'setColumn'
+    }
+  });
+  actionFunction('lineupAddColumn', 'addColumnImpl', () => System.import('./lineup/internal/cmds'), {
+    tdp_matomo: {
+      category: 'lineup',
+      action: 'addColumn'
+    }
+  });
+  actionFunction('lineupMoveColumn', 'moveColumnImpl', () => System.import('./lineup/internal/cmds'), {
+    tdp_matomo: {
+      category: 'lineup',
+      action: 'moveColumn'
+    }
+  });
 }

--- a/src/phovea.ts
+++ b/src/phovea.ts
@@ -15,13 +15,13 @@ export default function (registry: IRegistry) {
   }
 
   actionFunction('tdpInitSession', 'initSessionImpl', () => System.import('./internal/cmds'), {
-    tdp_matomo: {
+    analytics: {
       category: 'session',
       action: 'init'
     }
   });
   actionFunction('tdpSetParameter', 'setParameterImpl', () => System.import('./internal/cmds'), {
-    tdp_matomo: {
+    analytics: {
       category: 'view',
       action: 'setParameter'
     }
@@ -35,13 +35,13 @@ export default function (registry: IRegistry) {
 
 
   actionFunction('tdpAddScore', 'addScoreImpl', () => System.import('./lineup/internal/scorecmds'), {
-    tdp_matomo: {
+    analytics: {
       category: 'score',
       action: 'add'
     }
   });
   actionFunction('tdpRemoveScore', 'removeScoreImpl', () => System.import('./lineup/internal/scorecmds'), {
-    tdp_matomo: {
+    analytics: {
       category: 'score',
       action: 'remove'
     }
@@ -54,43 +54,43 @@ export default function (registry: IRegistry) {
   actionCompressor('ordinoScoreCompressor', 'compressComp', '(ordinoAddScore|ordinoRemoveScore)', () => System.import('./lineup/internal/scorecmds'));
 
   actionFunction('lineupAddRanking', 'addRankingImpl', () => System.import('./lineup/internal/cmds'), {
-    tdp_matomo: {
+    analytics: {
       category: 'lineup',
       action: 'addRanking'
     }
   });
   actionFunction('lineupSetRankingSortCriteria', 'setRankingSortCriteriaImpl', () => System.import('./lineup/internal/cmds'), {
-    tdp_matomo: {
+    analytics: {
       category: 'lineup',
       action: 'setRankingSortCriteria'
     }
   });
   actionFunction('lineupSetSortCriteria', 'setSortCriteriaImpl', () => System.import('./lineup/internal/cmds'), {
-    tdp_matomo: {
+    analytics: {
       category: 'lineup',
       action: 'setSortCriteria'
     }
   });
   actionFunction('lineupSetGroupCriteria', 'setGroupCriteriaImpl', () => System.import('./lineup/internal/cmds'), {
-    tdp_matomo: {
+    analytics: {
       category: 'lineup',
       action: 'setGroupCriteria'
     }
   });
   actionFunction('lineupSetColumn', 'setColumnImpl', () => System.import('./lineup/internal/cmds'), {
-    tdp_matomo: {
+    analytics: {
       category: 'lineup',
       action: 'setColumn'
     }
   });
   actionFunction('lineupAddColumn', 'addColumnImpl', () => System.import('./lineup/internal/cmds'), {
-    tdp_matomo: {
+    analytics: {
       category: 'lineup',
       action: 'addColumn'
     }
   });
   actionFunction('lineupMoveColumn', 'moveColumnImpl', () => System.import('./lineup/internal/cmds'), {
-    tdp_matomo: {
+    analytics: {
       category: 'lineup',
       action: 'moveColumn'
     }


### PR DESCRIPTION
Requires PR https://github.com/datavisyn/tdp_matomo/pull/3 to see the tracking in action. Without this plugin, nothing will happen.

## Changes

* Before this PR the matomo tracking for `actionFunctions` of tdp_core has been hard-coded in [tdp_matomo](https://github.com/datavisyn/tdp_matomo/blob/981f6df5b1ec1f4b81df78eba0f4c945aa12f2cd/src/actions.ts#L12-L27)
* Now the matomo plugin is looking for annotated phovea extensions of extension point `actionFunction` and tracks these functions
* The new properity is used by tdp_matomo
* The properties of the configuration follow the `IMatomoEvent` interface