### PR TITLE
Update to LineUp v3.2 and adapt to changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@types/d3": "3.5.36",
     "@types/select2": "4.0.41",
     "d3": "3.5.17",
-    "lineupjs": "~3.2.0",
+    "lineupjs": "~3.2.1",
     "phovea_clue": "~2.2.0",
     "select2": "4.0.4",
     "select2-bootstrap-theme": "0.1.0-beta.9",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@types/d3": "3.5.36",
     "@types/select2": "4.0.41",
     "d3": "3.5.17",
-    "lineupjs": "~3.1.7",
+    "lineupjs": "~3.2.0",
     "phovea_clue": "~2.2.0",
     "select2": "4.0.4",
     "select2-bootstrap-theme": "0.1.0-beta.9",

--- a/src/lineup/ARankingView.ts
+++ b/src/lineup/ARankingView.ts
@@ -389,7 +389,8 @@ export abstract class ARankingView extends AView {
   }
 
   private addColumn(colDesc: any, data: Promise<IScoreRow<any>[]>, id = -1, position?: number) {
-    colDesc.color = colDesc.color? colDesc.color : this.colors.getColumnColor(id);
+    // use `colorMapping` as default; otherwise use `color`, which is deprecated; else get a new color
+    colDesc.colorMapping = colDesc.colorMapping ? colDesc.colorMapping : (colDesc.color ? colDesc.color : this.colors.getColumnColor(id));
     return addLazyColumn(colDesc, data, this.provider, position, () => {
       this.taggle.update();
       this.panel.updateChooser(this.itemIDType, this.provider.getColumns());

--- a/src/lineup/ARankingView.ts
+++ b/src/lineup/ARankingView.ts
@@ -509,7 +509,6 @@ export abstract class ARankingView extends AView {
       this.createInitialRanking(this.provider);
       const ranking = this.provider.getLastRanking();
       this.customizeRanking(wrapRanking(this.provider, ranking));
-      this.colors.init(ranking);
     }).then(() => {
       if (this.selectionAdapter) {
         // init first time

--- a/src/lineup/internal/LineUpColors.ts
+++ b/src/lineup/internal/LineUpColors.ts
@@ -7,19 +7,7 @@ export default class LineUpColors {
    * Map that assigns each selection ID a color, which is used as color for columns
    */
   private readonly colorMap = new Map<number, {color: string, items: number}>();
-  private colors: string[];
-
-  init(ranking: Ranking) {
-    const colors = scale.category10().range().concat(scale.category20().range().filter((_d,i) => i % 2 === 1));
-    // remove colors that are already in use from the list
-    ranking.flatColumns.forEach((d) => {
-      const i = colors.indexOf(d.color);
-      if (i > -1) {
-        colors.splice(i, 1);
-      }
-    });
-    this.colors = colors;
-  }
+  private colors: string[] = scale.category10().range().concat(scale.category20().range().filter((_d,i) => i % 2 === 1));
 
   getColumnColor(id: number): string {
     if (id < 0) {


### PR DESCRIPTION
Fixes #210 

### Summary

* Update to [LineUp v3.2.0](https://github.com/lineupjs/lineupjs/releases/tag/v3.2.0)
* Use `colorMapping` property for column description as default
* Remove check of used colors in ranking, because `Column.color` was removed is only available on a per row basis (and we do not have a row).
