### PR TITLE
added rel=noopener to target=_blank links

### DIFF
--- a/src/base/ViewWrapper.ts
+++ b/src/base/ViewWrapper.ts
@@ -77,7 +77,7 @@ export default class ViewWrapper extends EventHandler implements IViewProvider {
     this.node.classList.toggle('not-allowed', !this.allowed);
 
     if (plugin.helpText) {
-      this.node.insertAdjacentHTML('beforeend', `<a href="#" target="_blank" class="view-help" title="Show help of this view"><span aria-hidden="true">Show Help</span></a>`);
+      this.node.insertAdjacentHTML('beforeend', `<a href="#" target="_blank" rel="noopener" class="view-help" title="Show help of this view"><span aria-hidden="true">Show Help</span></a>`);
       this.node.lastElementChild!.addEventListener('click', (evt) => {
         evt.preventDefault();
         evt.stopPropagation();
@@ -90,12 +90,12 @@ export default class ViewWrapper extends EventHandler implements IViewProvider {
       });
     } else if (plugin.helpUrl) {
       if (typeof plugin.helpUrl === 'string') {
-        this.node.insertAdjacentHTML('beforeend', `<a href="${plugin.helpUrl}" target="_blank" class="view-help" title="Show help of this view"><span aria-hidden="true">Show Help</span></a>`);
+        this.node.insertAdjacentHTML('beforeend', `<a href="${plugin.helpUrl}" target="_blank" rel="noopener" class="view-help" title="Show help of this view"><span aria-hidden="true">Show Help</span></a>`);
       } else { // object version of helpUrl
-        this.node.insertAdjacentHTML('beforeend', `<a href="${plugin.helpUrl.url}" target="_blank" class="view-help" title="${plugin.helpUrl.title}"><span aria-hidden="true">${plugin.helpUrl.linkText}</span></a>`);
+        this.node.insertAdjacentHTML('beforeend', `<a href="${plugin.helpUrl.url}" target="_blank" rel="noopener" class="view-help" title="${plugin.helpUrl.title}"><span aria-hidden="true">${plugin.helpUrl.linkText}</span></a>`);
       }
     } else if (plugin.helpTourId) {
-      this.node.insertAdjacentHTML('beforeend', `<a href="#" target="_blank" class="view-help" title="Show help tour of this view"><span aria-hidden="true">Show Help Tour</span></a>`);
+      this.node.insertAdjacentHTML('beforeend', `<a href="#" target="_blank" rel="noopener" class="view-help" title="Show help tour of this view"><span aria-hidden="true">Show Help Tour</span></a>`);
       this.node.lastElementChild!.addEventListener('click', (evt) => {
         evt.preventDefault();
         evt.stopPropagation();

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -48,7 +48,7 @@ let errorAlertHandler = (error: any) => {
     return xhr.text().then((body: string) => {
       if (xhr.status !== 400) {
         body = `${body}<hr>
-          The requested URL was:<br><a href="${xhr.url}" target="_blank" class="alert-link">${(xhr.url.length > 100) ? xhr.url.substring(0, 100) + '...' : xhr.url}</a>`;
+          The requested URL was:<br><a href="${xhr.url}" target="_blank" rel="noopener" class="alert-link">${(xhr.url.length > 100) ? xhr.url.substring(0, 100) + '...' : xhr.url}</a>`;
       }
       pushNotification('danger', `<strong>Error ${xhr.status} (${xhr.statusText})</strong>: ${body}`, DEFAULT_ERROR_AUTO_HIDE);
       return Promise.reject(error);

--- a/src/views/ChooserProxyView.ts
+++ b/src/views/ChooserProxyView.ts
@@ -139,7 +139,7 @@ export default class ChooserProxyView extends AView {
       return;
     }
 
-    this.openExternally.innerHTML = `The web page below is directly loaded from <a href="${url}" target="_blank"><i class="fa fa-external-link"></i>${url.startsWith('http') ? url : `${location.protocol}${url}`}</a>`;
+    this.openExternally.innerHTML = `The web page below is directly loaded from <a href="${url}" target="_blank" rel="noopener"><i class="fa fa-external-link"></i>${url.startsWith('http') ? url : `${location.protocol}${url}`}</a>`;
 
     const iframe = this.node.ownerDocument.createElement('iframe');
     iframe.src = url;
@@ -170,8 +170,8 @@ export default class ChooserProxyView extends AView {
     this.node.innerHTML = `
         <p><div class="alert alert-info center-block" role="alert" style="max-width: 40em"><strong>Security Information: </strong>This website uses HTTPS to secure your communication with our server.
             However, the requested external website doesn't support HTTPS and thus cannot be directly embedded in this application.
-            Please use the following <a href="${url}" target="_blank" class="alert-link">link</a> to open the website in a separate window:
-            <br><br><a href="${url}" target="_blank" class="alert-link">${url}</a>
+            Please use the following <a href="${url}" target="_blank" rel="noopener" class="alert-link">link</a> to open the website in a separate window:
+            <br><br><a href="${url}" target="_blank" rel="noopener" class="alert-link">${url}</a>
         </div></p><p></p>`;
     this.openExternally.innerHTML = ``;
     this.fire(ChooserProxyView.EVENT_LOADING_FINISHED);

--- a/src/views/ProxyView.ts
+++ b/src/views/ProxyView.ts
@@ -181,7 +181,7 @@ export default class ProxyView extends AD3View {
       return;
     }
 
-    this.openExternally.innerHTML = `The web page below is directly loaded from <a href="${url}" target="_blank"><i class="fa fa-external-link"></i>${url.startsWith('http') ? url: `${location.protocol}${url}`}</a>`;
+    this.openExternally.innerHTML = `The web page below is directly loaded from <a href="${url}" target="_blank" rel="noopener"><i class="fa fa-external-link"></i>${url.startsWith('http') ? url: `${location.protocol}${url}`}</a>`;
 
     //console.log('start loading', this.$node.select('iframe').node().getBoundingClientRect());
     this.$node.append('iframe')
@@ -214,8 +214,8 @@ export default class ProxyView extends AD3View {
     this.$node.html(`
         <p><div class="alert alert-info center-block" role="alert" style="max-width: 40em"><strong>Security Information: </strong>This website uses HTTPS to secure your communication with our server.
             However, the requested external website doesn't support HTTPS and thus cannot be directly embedded in this application.
-            Please use the following <a href="${url}" target="_blank" class="alert-link">link</a> to open the website in a separate window:
-            <br><br><a href="${url}" target="_blank" class="alert-link">${url}</a>
+            Please use the following <a href="${url}" target="_blank" rel="noopener" class="alert-link">link</a> to open the website in a separate window:
+            <br><br><a href="${url}" target="_blank" rel="noopener" class="alert-link">${url}</a>
         </div></p><p></p>`);
     this.openExternally.innerHTML = ``;
     this.fire(ProxyView.EVENT_LOADING_FINISHED);

--- a/src/views/messaging/MessagingProxyView.ts
+++ b/src/views/messaging/MessagingProxyView.ts
@@ -220,8 +220,8 @@ export default class MessagingProxyView extends AView {
     this.node.innerHTML = `
         <p><div class="alert alert-info center-block" role="alert" style="max-width: 40em"><strong>Security Information: </strong>This website uses HTTPS to secure your communication with our server.
             However, the requested external website doesn't support HTTPS and thus cannot be directly embedded in this application.
-            Please use the following <a href="${url}" target="_blank" class="alert-link">link</a> to open the website in a separate window:
-            <br><br><a href="${url}" target="_blank" class="alert-link">${url}</a>
+            Please use the following <a href="${url}" target="_blank" rel="noopener" class="alert-link">link</a> to open the website in a separate window:
+            <br><br><a href="${url}" target="_blank" rel="noopener" class="alert-link">${url}</a>
         </div></p><p></p>`;
     this.fire(MessagingProxyView.EVENT_LOADING_FINISHED);
   }


### PR DESCRIPTION
browsers (e.g. Firefox ESR --> version 60.4.0esr AND Chromium version 77.0.3865.75; Firefox Developer Edition (version 70.0b6) are vulnerable to an attack where when opening a link in a new tab the window object of the previous tab is available in the new one.

If an external malicious website we link to (the external website could get hacked, too) overwrites the location of the window object of the original tab to a fake login page our customers could be victims of phishing attacks

for more information and to test it with other browsers, please refer to https://mathiasbynens.github.io/rel-noopener/