### PR TITLE
Fix wrong order of form elements

### DIFF
--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -29,7 +29,6 @@ export const EXTENSION_POINT_TDP_VIEW_GROUPS = 'tdpViewGroups';
  * @registryParam {object} [parameter] The registry parameter depend on the form element. Hence, all defined parameters are passed to the form element as `pluginDesc`.
  *
  * @factoryParam {Form} form The form this element is a part of
- * @factoryParam {D3.Selction} $parent The parent node this element will be attached to
  * @factoryParam {IFormElementDesc} elementDesc The form element description from the form builder
  * @factoryParam {IPluginDesc} pluginDesc The phovea extension point options
  * @factoryReturns {IFormElement} An instance of the form element

--- a/src/form/FormBuilder.ts
+++ b/src/form/FormBuilder.ts
@@ -42,11 +42,6 @@ export default class FormBuilder {
 
     const elementPromise = create(this.form, this.form.$node, desc);
     this.elementPromises.push(elementPromise);
-
-    // append element to form once it is loaded
-    elementPromise.then((element: IFormElement) => {
-      this.form.appendElement(element);
-    });
   }
 
   /**
@@ -68,7 +63,8 @@ export default class FormBuilder {
   build(): Promise<IForm> {
     // initialize when all elements are loaded
     return Promise.all(this.elementPromises)
-      .then(() => {
+      .then((elements: IFormElement[]) => {
+        this.form.appendElements(elements);
         this.form.initAllElements();
         return this.form;
       });

--- a/src/form/FormBuilder.ts
+++ b/src/form/FormBuilder.ts
@@ -69,7 +69,7 @@ export default class FormBuilder {
     // initialize when all elements are loaded
     return Promise.all(this.elementPromises)
       .then(() => {
-        this.form.initializeAllElements();
+        this.form.initAllElements();
         return this.form;
       });
   }

--- a/src/form/FormBuilder.ts
+++ b/src/form/FormBuilder.ts
@@ -40,7 +40,7 @@ export default class FormBuilder {
   appendElement(elementDesc: IFormElementDesc) {
     const desc = updateElementDesc(elementDesc, this.formId);
 
-    const elementPromise = create(this.form, this.form.$node, desc);
+    const elementPromise = create(this.form, desc);
     this.elementPromises.push(elementPromise);
   }
 

--- a/src/form/elements/AFormElement.ts
+++ b/src/form/elements/AFormElement.ts
@@ -28,7 +28,7 @@ export abstract class AFormElement<T extends IFormElementDesc> extends EventHand
    * @param elementDesc The form element description
    * @param pluginDesc The phovea extension point description
    */
-  constructor(protected readonly form: IForm, protected readonly elementDesc: T, protected readonly pluginDesc: IPluginDesc) {
+  constructor(protected readonly form: IForm, protected readonly $parent: Selection<any>, protected readonly elementDesc: T, protected readonly pluginDesc: IPluginDesc) {
     super();
     this.id = elementDesc.id;
 
@@ -79,10 +79,10 @@ export abstract class AFormElement<T extends IFormElementDesc> extends EventHand
   }
 
   /**
-   * Set the visibility of an form element
+   * Set the visibility of an form element (default = true)
    * @param visible
    */
-  setVisible(visible: boolean) {
+  setVisible(visible: boolean = true) {
     this.$node.classed('hidden', !visible);
   }
 
@@ -105,23 +105,27 @@ export abstract class AFormElement<T extends IFormElementDesc> extends EventHand
     this.elementDesc.onChange(this, value, toData(value), old);
   }
 
-  protected build() {
-    this.addChangeListener();
-
-    if (this.elementDesc.visible === false) {
-      this.$node.classed('hidden', true);
-    }
-
-    if (!this.elementDesc.hideLabel) {
-      this.$node.append('label').attr('for', this.elementDesc.attributes.id).text(this.elementDesc.label);
-    }
-  }
+  /**
+   * Build the current element and add the DOM element to the form DOM element.
+   * The implementation of this function must set the `$node` property!
+   */
+  abstract build();
 
   /**
    * Initialize dependent form fields, bind the change listener, and propagate the selection by firing a change event
    */
   init() {
     // hook
+  }
+
+  /**
+   * Append a label to the node element if `hideLabel = false` in the element description
+   */
+  protected appendLabel() {
+    if (this.elementDesc.hideLabel) {
+      return;
+    }
+    this.$node.append('label').attr('for', this.elementDesc.attributes.id).text(this.elementDesc.label);
   }
 
   /**

--- a/src/form/elements/AFormElement.ts
+++ b/src/form/elements/AFormElement.ts
@@ -24,11 +24,10 @@ export abstract class AFormElement<T extends IFormElementDesc> extends EventHand
   /**
    * Constructor
    * @param form The form this element is a part of
-   * @param $parent The parent node this element will be attached to
    * @param elementDesc The form element description
    * @param pluginDesc The phovea extension point description
    */
-  constructor(protected readonly form: IForm, protected readonly $parent: Selection<any>, protected readonly elementDesc: T, protected readonly pluginDesc: IPluginDesc) {
+  constructor(protected readonly form: IForm, protected readonly elementDesc: T, protected readonly pluginDesc: IPluginDesc) {
     super();
     this.id = elementDesc.id;
 
@@ -109,7 +108,7 @@ export abstract class AFormElement<T extends IFormElementDesc> extends EventHand
    * Build the current element and add the DOM element to the form DOM element.
    * The implementation of this function must set the `$node` property!
    */
-  abstract build();
+  abstract build($formNode: Selection<any>);
 
   /**
    * Initialize dependent form fields, bind the change listener, and propagate the selection by firing a change event

--- a/src/form/elements/Form.ts
+++ b/src/form/elements/Form.ts
@@ -54,11 +54,21 @@ export class Form implements IForm {
 
   /**
    * Append a form element and builds it
-   * Note: The initialization of the element must be done using `initializeAllElements`
+   * Note: The initialization of the element must be done using `initAllElements()`
    * @param element Form element
    */
   appendElement(element: IFormElement) {
+    element.build();
     this.elements.set(element.id, element);
+  }
+
+  /**
+   * Append multiple form element at once and and build them
+   * Note: The initialization of the element must be done using `initAllElements()`
+   * @param element Form element
+   */
+  appendElements(elements: IFormElement[]) {
+    elements.forEach((element) => this.appendElement(element));
   }
 
   /**

--- a/src/form/elements/Form.ts
+++ b/src/form/elements/Form.ts
@@ -36,7 +36,7 @@ export class Form implements IForm {
   /**
    * DOM node for the form itself
    */
-  readonly $node: d3.Selection<any>;
+  private readonly $node: d3.Selection<any>;
 
   /**
    * Map of all appended form elements with the element id as key
@@ -58,7 +58,7 @@ export class Form implements IForm {
    * @param element Form element
    */
   appendElement(element: IFormElement) {
-    element.build();
+    element.build(this.$node);
     this.elements.set(element.id, element);
   }
 

--- a/src/form/elements/Form.ts
+++ b/src/form/elements/Form.ts
@@ -65,7 +65,7 @@ export class Form implements IForm {
    * Initialize all elements of this form
    * At this stage it is possible to reference dependencies to other form fields
    */
-  initializeAllElements() {
+  initAllElements() {
     this.elements.forEach((element) => element.init());
   }
 

--- a/src/form/elements/FormButton.ts
+++ b/src/form/elements/FormButton.ts
@@ -19,11 +19,10 @@ export default class FormButton extends EventHandler implements IFormElement {
   /**
    * Constructor
    * @param form The form this element is a part of
-   * @param $parent The parent node this element will be attached to
    * @param elementDesc The form element description
    * @param pluginDesc The phovea extension point description
    */
-  constructor(readonly form: IForm, private readonly $parent, readonly elementDesc: IButtonElementDesc, readonly pluginDesc: IPluginDesc) {
+  constructor(readonly form: IForm, readonly elementDesc: IButtonElementDesc, readonly pluginDesc: IPluginDesc) {
     super();
     this.id = elementDesc.id;
   }
@@ -48,8 +47,12 @@ export default class FormButton extends EventHandler implements IFormElement {
     return true;
   }
 
-  build() {
-    this.$node = this.$parent.append('div').classed('form-group', true);
+  /**
+   * Build the current element and add the DOM element to the form DOM element.
+   * @param $formNode The parent node this element will be attached to
+   */
+  build($formNode) {
+    this.$node = $formNode.append('div').classed('form-group', true);
     this.$button = this.$node.append('button').classed(this.elementDesc.attributes.clazz, true);
     this.$button.html(() => this.elementDesc.iconClass? `<i class="${this.elementDesc.iconClass}"></i> ${this.elementDesc.label}` : this.elementDesc.label);
   }

--- a/src/form/elements/FormButton.ts
+++ b/src/form/elements/FormButton.ts
@@ -23,11 +23,9 @@ export default class FormButton extends EventHandler implements IFormElement {
    * @param elementDesc The form element description
    * @param pluginDesc The phovea extension point description
    */
-  constructor(readonly form: IForm, readonly $parent, readonly elementDesc: IButtonElementDesc, readonly pluginDesc: IPluginDesc) {
+  constructor(readonly form: IForm, private readonly $parent, readonly elementDesc: IButtonElementDesc, readonly pluginDesc: IPluginDesc) {
     super();
     this.id = elementDesc.id;
-    this.$node = $parent.append('div').classed('form-group', true);
-    this.build();
   }
 
   /**
@@ -50,7 +48,8 @@ export default class FormButton extends EventHandler implements IFormElement {
     return true;
   }
 
-  protected build() {
+  build() {
+    this.$node = this.$parent.append('div').classed('form-group', true);
     this.$button = this.$node.append('button').classed(this.elementDesc.attributes.clazz, true);
     this.$button.html(() => this.elementDesc.iconClass? `<i class="${this.elementDesc.iconClass}"></i> ${this.elementDesc.label}` : this.elementDesc.label);
   }

--- a/src/form/elements/FormCheckBox.ts
+++ b/src/form/elements/FormCheckBox.ts
@@ -32,18 +32,19 @@ export default class FormCheckBox extends AFormElement<ICheckBoxElementDesc> {
    * @param pluginDesc The phovea extension point description
    */
   constructor(form: IForm, $parent: d3.Selection<any>, elementDesc: ICheckBoxElementDesc, readonly pluginDesc: IPluginDesc) {
-    super(form, Object.assign({options: { checked: true, unchecked: false}}, elementDesc), pluginDesc);
-
-    this.$node = $parent.append('div').classed('checkbox', true);
-
-    this.build();
+    super(form, $parent, Object.assign({options: { checked: true, unchecked: false}}, elementDesc), pluginDesc);
   }
 
   /**
    * Build the label and input element
    */
-  protected build() {
-    super.build();
+  build() {
+    this.addChangeListener();
+
+    this.$node = this.$parent.append('div').classed('checkbox', true);
+    this.setVisible(this.elementDesc.visible);
+    this.appendLabel();
+
     const $label = this.$node.select('label');
     if ($label.empty()) {
       this.$input = this.$node.append('input').attr('type', 'checkbox');

--- a/src/form/elements/FormCheckBox.ts
+++ b/src/form/elements/FormCheckBox.ts
@@ -27,21 +27,21 @@ export default class FormCheckBox extends AFormElement<ICheckBoxElementDesc> {
   /**
    * Constructor
    * @param form The form this element is a part of
-   * @param $parent The parent node this element will be attached to
    * @param elementDesc The form element description
    * @param pluginDesc The phovea extension point description
    */
-  constructor(form: IForm, $parent: d3.Selection<any>, elementDesc: ICheckBoxElementDesc, readonly pluginDesc: IPluginDesc) {
-    super(form, $parent, Object.assign({options: { checked: true, unchecked: false}}, elementDesc), pluginDesc);
+  constructor(form: IForm, elementDesc: ICheckBoxElementDesc, readonly pluginDesc: IPluginDesc) {
+    super(form, Object.assign({options: { checked: true, unchecked: false}}, elementDesc), pluginDesc);
   }
 
   /**
    * Build the label and input element
+   * @param $formNode The parent node this element will be attached to
    */
-  build() {
+  build($formNode: d3.Selection<any>) {
     this.addChangeListener();
 
-    this.$node = this.$parent.append('div').classed('checkbox', true);
+    this.$node = $formNode.append('div').classed('checkbox', true);
     this.setVisible(this.elementDesc.visible);
     this.appendLabel();
 

--- a/src/form/elements/FormInputText.ts
+++ b/src/form/elements/FormInputText.ts
@@ -42,18 +42,19 @@ export default class FormInputText extends AFormElement<IFormInputTextDesc> {
    * @param pluginDesc The phovea extension point description
    */
   constructor(form: IForm, $parent: d3.Selection<any>, elementDesc: IFormInputTextDesc, readonly pluginDesc: IPluginDesc) {
-    super(form, elementDesc, pluginDesc);
-
-    this.$node = $parent.append('div').classed('form-group', true);
-
-    this.build();
+    super(form, $parent, elementDesc, pluginDesc);
   }
 
   /**
    * Build the label and input element
    */
-  protected build() {
-    super.build();
+  build() {
+    this.addChangeListener();
+
+    this.$node = this.$parent.append('div').classed('form-group', true);
+    this.setVisible(this.elementDesc.visible);
+    this.appendLabel();
+
     this.$input = this.$node.append('input').attr('type', (this.elementDesc.options || {}).type || 'text');
     this.setAttributes(this.$input, this.elementDesc.attributes);
   }

--- a/src/form/elements/FormInputText.ts
+++ b/src/form/elements/FormInputText.ts
@@ -37,21 +37,21 @@ export default class FormInputText extends AFormElement<IFormInputTextDesc> {
   /**
    * Constructor
    * @param form The form this element is a part of
-   * @param $parent The parent node this element will be attached to
    * @param elementDesc The form element description
    * @param pluginDesc The phovea extension point description
    */
-  constructor(form: IForm, $parent: d3.Selection<any>, elementDesc: IFormInputTextDesc, readonly pluginDesc: IPluginDesc) {
-    super(form, $parent, elementDesc, pluginDesc);
+  constructor(form: IForm, elementDesc: IFormInputTextDesc, readonly pluginDesc: IPluginDesc) {
+    super(form, elementDesc, pluginDesc);
   }
 
   /**
    * Build the label and input element
+   * @param $formNode The parent node this element will be attached to
    */
-  build() {
+  build($formNode: d3.Selection<any>) {
     this.addChangeListener();
 
-    this.$node = this.$parent.append('div').classed('form-group', true);
+    this.$node = $formNode.append('div').classed('form-group', true);
     this.setVisible(this.elementDesc.visible);
     this.appendLabel();
 

--- a/src/form/elements/FormMap.ts
+++ b/src/form/elements/FormMap.ts
@@ -92,9 +92,9 @@ export default class FormMap extends AFormElement<IFormMapDesc> {
 
   private $group: d3.Selection<any>;
   private rows: IFormRow[] = [];
-  private readonly inline: boolean;
 
-  private readonly inlineOnChange: (formElement: IFormElement, value: any, data: any, previousValue: any)=>void;
+  private inline: boolean;
+  private inlineOnChange: (formElement: IFormElement, value: any, data: any, previousValue: any)=>void;
 
   /**
    * Constructor
@@ -104,17 +104,7 @@ export default class FormMap extends AFormElement<IFormMapDesc> {
    * @param pluginDesc The phovea extension point description
    */
   constructor(form: IForm, $parent, elementDesc: IFormMapDesc, readonly pluginDesc: IPluginDesc) {
-    super(form, elementDesc, pluginDesc);
-
-    this.$node = $parent.append('div').classed('form-group', true);
-    this.inline = hasInlineParent(<HTMLElement>this.$node.node());
-    if (this.inline && this.elementDesc.onChange) {
-      //change the default onChange handler for the inline cas
-      this.inlineOnChange = this.elementDesc.onChange;
-      this.elementDesc.onChange = null;
-    }
-
-    this.build();
+    super(form, $parent, elementDesc, pluginDesc);
   }
 
   private updateBadge() {
@@ -145,11 +135,17 @@ export default class FormMap extends AFormElement<IFormMapDesc> {
   /**
    * Build the label and input element
    */
-  protected build() {
+  build() {
     this.addChangeListener();
 
-    if (this.elementDesc.visible === false) {
-      this.$node.classed('hidden', true);
+    this.$node = this.$parent.append('div').classed('form-group', true);
+    this.setVisible(this.elementDesc.visible);
+
+    this.inline = hasInlineParent(<HTMLElement>this.$node.node());
+    if (this.inline && this.elementDesc.onChange) {
+      //change the default onChange handler for the inline cas
+      this.inlineOnChange = this.elementDesc.onChange;
+      this.elementDesc.onChange = null;
     }
 
     if (this.inline) {

--- a/src/form/elements/FormMap.ts
+++ b/src/form/elements/FormMap.ts
@@ -99,12 +99,11 @@ export default class FormMap extends AFormElement<IFormMapDesc> {
   /**
    * Constructor
    * @param form The form this element is a part of
-   * @param $parent The parent node this element will be attached to
    * @param elementDesc The form element description
    * @param pluginDesc The phovea extension point description
    */
-  constructor(form: IForm, $parent, elementDesc: IFormMapDesc, readonly pluginDesc: IPluginDesc) {
-    super(form, $parent, elementDesc, pluginDesc);
+  constructor(form: IForm, elementDesc: IFormMapDesc, readonly pluginDesc: IPluginDesc) {
+    super(form, elementDesc, pluginDesc);
   }
 
   private updateBadge() {
@@ -134,11 +133,12 @@ export default class FormMap extends AFormElement<IFormMapDesc> {
 
   /**
    * Build the label and input element
+   * @param $formNode The parent node this element will be attached to
    */
-  build() {
+  build($formNode: d3.Selection<any>) {
     this.addChangeListener();
 
-    this.$node = this.$parent.append('div').classed('form-group', true);
+    this.$node = $formNode.append('div').classed('form-group', true);
     this.setVisible(this.elementDesc.visible);
 
     this.inline = hasInlineParent(<HTMLElement>this.$node.node());

--- a/src/form/elements/FormRadio.ts
+++ b/src/form/elements/FormRadio.ts
@@ -20,18 +20,19 @@ export default class FormRadio extends AFormElement<IRadioElementDesc> {
    * @param pluginDesc The phovea extension point description
    */
   constructor(form: IForm, $parent: d3.Selection<any>, elementDesc: IRadioElementDesc, readonly pluginDesc: IPluginDesc) {
-    super(form, Object.assign({options: { buttons: [] }}, elementDesc), pluginDesc);
-
-    this.$node = $parent.append('div');
-
-    this.build();
+    super(form, $parent, Object.assign({options: { buttons: [] }}, elementDesc), pluginDesc);
   }
 
   /**
    * Build the label and input element
    */
-  protected build() {
-    super.build();
+  build() {
+    this.addChangeListener();
+
+    this.$node = this.$parent.append('div');
+    this.setVisible(this.elementDesc.visible);
+    this.appendLabel();
+
     const $label = this.$node.select('label');
 
     const options = this.elementDesc.options;
@@ -48,7 +49,6 @@ export default class FormRadio extends AFormElement<IRadioElementDesc> {
     // TODO: fix that the form-control class is only appended for textual form elements, not for all
     this.elementDesc.attributes.clazz = this.elementDesc.attributes.clazz.replace('form-control', ''); // filter out the form-control class, because it is mainly used for text inputs and destroys the styling of the radio
     this.setAttributes($buttonElements, this.elementDesc.attributes);
-
   }
 
   /**

--- a/src/form/elements/FormRadio.ts
+++ b/src/form/elements/FormRadio.ts
@@ -15,21 +15,21 @@ export default class FormRadio extends AFormElement<IRadioElementDesc> {
   /**
    * Constructor
    * @param form The form this element is a part of
-   * @param $parent The parent node this element will be attached to
    * @param elementDesc The form element description
    * @param pluginDesc The phovea extension point description
    */
-  constructor(form: IForm, $parent: d3.Selection<any>, elementDesc: IRadioElementDesc, readonly pluginDesc: IPluginDesc) {
-    super(form, $parent, Object.assign({options: { buttons: [] }}, elementDesc), pluginDesc);
+  constructor(form: IForm, elementDesc: IRadioElementDesc, readonly pluginDesc: IPluginDesc) {
+    super(form, Object.assign({options: { buttons: [] }}, elementDesc), pluginDesc);
   }
 
   /**
    * Build the label and input element
+   * @param $formNode The parent node this element will be attached to
    */
-  build() {
+  build($formNode: d3.Selection<any>) {
     this.addChangeListener();
 
-    this.$node = this.$parent.append('div');
+    this.$node = $formNode.append('div');
     this.setVisible(this.elementDesc.visible);
     this.appendLabel();
 

--- a/src/form/elements/FormSelect.ts
+++ b/src/form/elements/FormSelect.ts
@@ -67,11 +67,7 @@ export default class FormSelect extends AFormElement<IFormSelectDesc> implements
    * @param pluginDesc The phovea extension point description
    */
   constructor(form: IForm, $parent: d3.Selection<any>, elementDesc: IFormSelectDesc, readonly pluginDesc: IPluginDesc) {
-    super(form, elementDesc, pluginDesc);
-
-    this.$node = $parent.append('div').classed('form-group', true);
-
-    this.build();
+    super(form, $parent, elementDesc, pluginDesc);
   }
 
   protected updateStoredValue() {
@@ -91,8 +87,12 @@ export default class FormSelect extends AFormElement<IFormSelectDesc> implements
   /**
    * Build the label and select element
    */
-  protected build() {
-    super.build();
+  build() {
+    this.addChangeListener();
+
+    this.$node = this.$parent.append('div').classed('form-group', true);
+    this.setVisible(this.elementDesc.visible);
+    this.appendLabel();
 
     this.$select = this.$node.append('select');
     this.setAttributes(this.$select, this.elementDesc.attributes);

--- a/src/form/elements/FormSelect.ts
+++ b/src/form/elements/FormSelect.ts
@@ -62,12 +62,11 @@ export default class FormSelect extends AFormElement<IFormSelectDesc> implements
   /**
    * Constructor
    * @param form The form this element is a part of
-   * @param $parent The parent node this element will be attached to
    * @param elementDesc The form element description
    * @param pluginDesc The phovea extension point description
    */
-  constructor(form: IForm, $parent: d3.Selection<any>, elementDesc: IFormSelectDesc, readonly pluginDesc: IPluginDesc) {
-    super(form, $parent, elementDesc, pluginDesc);
+  constructor(form: IForm, elementDesc: IFormSelectDesc, readonly pluginDesc: IPluginDesc) {
+    super(form, elementDesc, pluginDesc);
   }
 
   protected updateStoredValue() {
@@ -86,11 +85,12 @@ export default class FormSelect extends AFormElement<IFormSelectDesc> implements
 
   /**
    * Build the label and select element
+   * @param $formNode The parent node this element will be attached to
    */
-  build() {
+  build($formNode: d3.Selection<any>) {
     this.addChangeListener();
 
-    this.$node = this.$parent.append('div').classed('form-group', true);
+    this.$node = $formNode.append('div').classed('form-group', true);
     this.setVisible(this.elementDesc.visible);
     this.appendLabel();
 

--- a/src/form/elements/FormSelect2.ts
+++ b/src/form/elements/FormSelect2.ts
@@ -87,23 +87,23 @@ export default class FormSelect2 extends AFormElement<IFormSelect2> {
   /**
    * Constructor
    * @param form The form this element is a part of
-   * @param $parent The parent node this element will be attached to
    * @param elementDesc The form element description
    * @param pluginDesc The phovea extension point description
    */
-  constructor(form: IForm, $parent, elementDesc: IFormSelect2, readonly pluginDesc: IPluginDesc) {
-    super(form, $parent, elementDesc, pluginDesc);
+  constructor(form: IForm, elementDesc: IFormSelect2, readonly pluginDesc: IPluginDesc) {
+    super(form,elementDesc, pluginDesc);
 
     this.isMultiple = (pluginDesc.selection === 'multiple');
   }
 
   /**
    * Build the label and select element
+   * @param $formNode The parent node this element will be attached to
    */
-  build() {
+  build($formNode: d3.Selection<any>) {
     this.addChangeListener();
 
-    this.$node = this.$parent.append('div').classed('form-group', true);
+    this.$node = $formNode.append('div').classed('form-group', true);
     this.setVisible(this.elementDesc.visible);
     this.appendLabel();
 

--- a/src/form/elements/FormSelect2.ts
+++ b/src/form/elements/FormSelect2.ts
@@ -92,24 +92,23 @@ export default class FormSelect2 extends AFormElement<IFormSelect2> {
    * @param pluginDesc The phovea extension point description
    */
   constructor(form: IForm, $parent, elementDesc: IFormSelect2, readonly pluginDesc: IPluginDesc) {
-    super(form, elementDesc, pluginDesc);
-
-    this.$node = $parent.append('div').classed('form-group', true);
+    super(form, $parent, elementDesc, pluginDesc);
 
     this.isMultiple = (pluginDesc.selection === 'multiple');
-
-    this.build();
   }
 
   /**
    * Build the label and select element
    */
-  protected build() {
-    super.build();
+  build() {
+    this.addChangeListener();
+
+    this.$node = this.$parent.append('div').classed('form-group', true);
+    this.setVisible(this.elementDesc.visible);
+    this.appendLabel();
 
     this.$select = this.$node.append('select');
     this.setAttributes(this.$select, this.elementDesc.attributes);
-
   }
 
   /**

--- a/src/form/elements/FormSelect3.ts
+++ b/src/form/elements/FormSelect3.ts
@@ -42,19 +42,20 @@ export default class FormSelect3 extends AFormElement<IFormSelect3> {
    * @param pluginDesc The phovea extension point description
    */
   constructor(form: IForm, $parent, desc: IFormSelect3, readonly pluginDesc: IPluginDesc) {
-    super(form, desc, pluginDesc);
+    super(form, $parent, desc, pluginDesc);
 
-    this.$node = $parent.append('div').classed('form-group', true);
     this.isMultiple = (pluginDesc.selection === 'multiple');
-
-    this.build();
   }
 
   /**
    * Build the label and select element
    */
-  protected build() {
-    super.build();
+  build() {
+    this.addChangeListener();
+
+    this.$node = this.$parent.append('div').classed('form-group', true);
+    this.setVisible(this.elementDesc.visible);
+    this.appendLabel();
 
     const options = Object.assign(this.elementDesc.options, {multiple: this.isMultiple});
     this.select3 = new Select3(options);
@@ -62,7 +63,6 @@ export default class FormSelect3 extends AFormElement<IFormSelect3> {
 
     this.elementDesc.attributes.clazz = this.elementDesc.attributes.clazz.replace('form-control', ''); // filter out the form-control class, because the border it creates doesn't contain the whole element due to absolute positioning and it isn't necessary
     this.setAttributes(this.$node.select('.select3'), this.elementDesc.attributes);
-
   }
 
   /**

--- a/src/form/elements/FormSelect3.ts
+++ b/src/form/elements/FormSelect3.ts
@@ -37,23 +37,23 @@ export default class FormSelect3 extends AFormElement<IFormSelect3> {
   /**
    * Constructor
    * @param form The form this element is a part of
-   * @param $parent The parent node this element will be attached to
    * @param elementDesc The form element description
    * @param pluginDesc The phovea extension point description
    */
-  constructor(form: IForm, $parent, desc: IFormSelect3, readonly pluginDesc: IPluginDesc) {
-    super(form, $parent, desc, pluginDesc);
+  constructor(form: IForm, desc: IFormSelect3, readonly pluginDesc: IPluginDesc) {
+    super(form, desc, pluginDesc);
 
     this.isMultiple = (pluginDesc.selection === 'multiple');
   }
 
   /**
    * Build the label and select element
+   * @param $formNode The parent node this element will be attached to
    */
-  build() {
+  build($formNode: d3.Selection<any>) {
     this.addChangeListener();
 
-    this.$node = this.$parent.append('div').classed('form-group', true);
+    this.$node = $formNode.append('div').classed('form-group', true);
     this.setVisible(this.elementDesc.visible);
     this.appendLabel();
 

--- a/src/form/elements/index.ts
+++ b/src/form/elements/index.ts
@@ -13,12 +13,12 @@ import {EP_TDP_CORE_FORM_ELEMENT} from '../../extensions';
  * @param $parent parent D3 selection element
  * @param elementDesc form element description
  */
-export function create(form: IForm, $parent: d3.Selection<any>, elementDesc: IFormElementDesc): Promise<IFormElement> {
+export function create(form: IForm, elementDesc: IFormElementDesc): Promise<IFormElement> {
   const plugin = get(EP_TDP_CORE_FORM_ELEMENT, elementDesc.type);
   if(!plugin) {
     throw new Error('unknown form element type: ' + elementDesc.type);
   }
   return plugin.load().then((p) => {
-    return p.factory(form, $parent, <any>elementDesc, p.desc);
+    return p.factory(form, <any>elementDesc, p.desc);
   });
 }

--- a/src/form/interfaces.ts
+++ b/src/form/interfaces.ts
@@ -152,10 +152,17 @@ export interface IForm {
 
   /**
    * Append a form element and builds it
-   * Note: The initialization of the element must be done using `initializeAllElements`
+   * Note: The initialization of the element must be done using `initAllElements()`
    * @param element Form element
    */
   appendElement(element: IFormElement);
+
+  /**
+   * Append multiple form element at once and build them
+   * Note: The initialization of the element must be done using `initAllElements()`
+   * @param element Form element
+   */
+  appendElements(element: IFormElement[]);
 
   /**
    * Initialize all elements of this form
@@ -206,6 +213,11 @@ export interface IFormElement extends IEventHandler {
    * Form element value
    */
   value: any;
+
+  /**
+   * Build the current element and add the DOM element to the form DOM element.
+   */
+  build(): void;
 
   /**
    * Initialize the current element

--- a/src/form/interfaces.ts
+++ b/src/form/interfaces.ts
@@ -146,11 +146,6 @@ export interface IFormElementDesc {
 
 export interface IForm {
   /**
-   * The DOM node as D3 selection
-   */
-  $node: d3.Selection<any>;
-
-  /**
    * Append a form element and builds it
    * Note: The initialization of the element must be done using `initAllElements()`
    * @param element Form element
@@ -216,8 +211,9 @@ export interface IFormElement extends IEventHandler {
 
   /**
    * Build the current element and add the DOM element to the form DOM element.
+   * @param $formNode The parent node this element will be attached to
    */
-  build(): void;
+  build($formNode: d3.Selection<any>): void;
 
   /**
    * Initialize the current element

--- a/src/form/interfaces.ts
+++ b/src/form/interfaces.ts
@@ -161,7 +161,7 @@ export interface IForm {
    * Initialize all elements of this form
    * At this stage it is possible to reference dependencies to other form fields
    */
-  initializeAllElements();
+  initAllElements();
 
   /**
    * Retrieve element by identifer


### PR DESCRIPTION
Fixes #216 

### Summary

The bug was introduced with the custom form elements in PR https://github.com/datavisyn/tdp_core/pull/185, due to different speed of the promises and the direct initialization of the DOM form elements.

This PR introduces a separate _build_ phase after all form elements are loaded. Hence, it is forbidden to 

* Rename `initializeAllElements` to `initAllElements` in `IForm`
* Make `build()` on `IFormElement` public
* Define `build()` as abstract function on `AFormElement`
* Remove $parent from constructor parameter list for form elements
  * Implicitly changes the extension point parameter list
  * Allows to make `$node` on `IForm` private again
* Set default value for `setVisible` to true (incase of `undefined` or `null` parameter)