### PR TITLE
Fix wrong CSS classes for Select3

### DIFF
--- a/src/form/elements/AFormElement.ts
+++ b/src/form/elements/AFormElement.ts
@@ -139,7 +139,15 @@ export abstract class AFormElement<T extends IFormElementDesc> extends EventHand
     }
 
     Object.keys(attributes).forEach((key) => {
-      $node.attr((key === 'clazz') ? 'class' : key, attributes[key]);
+      switch (key) {
+        case 'clazz':
+          const cssClasses = attributes[key].split(' '); // tokenize CSS classes at space
+          cssClasses.forEach((cssClass) => $node.classed(cssClass, true));
+          break;
+        default:
+          $node.attr(key, attributes[key]);
+          break;
+      }
     });
 
     if (this.elementDesc.required && !this.elementDesc.showIf) {

--- a/src/form/elements/FormSelect3.ts
+++ b/src/form/elements/FormSelect3.ts
@@ -40,8 +40,8 @@ export default class FormSelect3 extends AFormElement<IFormSelect3> {
    * @param elementDesc The form element description
    * @param pluginDesc The phovea extension point description
    */
-  constructor(form: IForm, desc: IFormSelect3, readonly pluginDesc: IPluginDesc) {
-    super(form, desc, pluginDesc);
+  constructor(form: IForm, elementDesc: IFormSelect3, readonly pluginDesc: IPluginDesc) {
+    super(form, elementDesc, pluginDesc);
 
     this.isMultiple = (pluginDesc.selection === 'multiple');
   }

--- a/src/form/elements/FormSelect3.ts
+++ b/src/form/elements/FormSelect3.ts
@@ -60,9 +60,6 @@ export default class FormSelect3 extends AFormElement<IFormSelect3> {
     const options = Object.assign(this.elementDesc.options, {multiple: this.isMultiple});
     this.select3 = new Select3(options);
     this.$node.node().appendChild(this.select3.node);
-
-    this.elementDesc.attributes.clazz = this.elementDesc.attributes.clazz.replace('form-control', ''); // filter out the form-control class, because the border it creates doesn't contain the whole element due to absolute positioning and it isn't necessary
-    this.setAttributes(this.$node.select('.select3'), this.elementDesc.attributes);
   }
 
   /**

--- a/src/form/elements/FormSelect3.ts
+++ b/src/form/elements/FormSelect3.ts
@@ -60,6 +60,9 @@ export default class FormSelect3 extends AFormElement<IFormSelect3> {
     const options = Object.assign(this.elementDesc.options, {multiple: this.isMultiple});
     this.select3 = new Select3(options);
     this.$node.node().appendChild(this.select3.node);
+
+    this.elementDesc.attributes.clazz = this.elementDesc.attributes.clazz.replace('form-control', ''); // filter out the form-control class, because the border it creates doesn't contain the whole element due to absolute positioning and it isn't necessary
+    this.setAttributes(this.$node.select('.select3'), this.elementDesc.attributes);
   }
 
   /**


### PR DESCRIPTION
Fixes #224 

### Summary

* Fix `AFormElement.setAttribute()` that CSS classes are added one-by-one (using D3 `classed`) instead of replacing the whole class attribute

**Before this PR**

Ordino public (left) and local version (right)

![grafik](https://user-images.githubusercontent.com/5851088/65770725-f36cfb00-e136-11e9-97c0-2127ffc7d1a9.png)

**After this PR**

Ordino public (left) and local version (right)

![grafik](https://user-images.githubusercontent.com/5851088/65771820-53fd3780-e139-11e9-8a26-9e7ba47d6597.png)

With this change the Ordino tour is working (again) as expected.

![ordino-fixed-tour](https://user-images.githubusercontent.com/5851088/65772465-8c514580-e13a-11e9-9fde-a0ad2a2a80c9.gif)
