### PR TITLE
Added support for getParameterFormDescs in AEmbeddedRanking

### DIFF
--- a/src/base/AEmbeddedRanking.ts
+++ b/src/base/AEmbeddedRanking.ts
@@ -107,7 +107,7 @@ export abstract class AEmbeddedRanking<T extends IRow> implements IViewProvider 
         return super.withoutTracking(f);
       }
 
-      protected getParameterFormDescs() {
+      protected getParameterFormDescs(): IFormElementDesc[] {
         const base = super.getParameterFormDescs();
         return [
           ...base,

--- a/src/base/AEmbeddedRanking.ts
+++ b/src/base/AEmbeddedRanking.ts
@@ -7,6 +7,7 @@ import {IViewProvider} from '../lineup/internal/cmds';
 import {resolve} from 'phovea_core/src/idtype';
 import {EXTENSION_POINT_TDP_SCORE_IMPL} from '../extensions';
 import {get as getPlugin} from 'phovea_core/src/plugin';
+import {IFormElementDesc} from '../form';
 
 
 interface IEmbeddedRanking extends ARankingView {
@@ -105,6 +106,14 @@ export abstract class AEmbeddedRanking<T extends IRow> implements IViewProvider 
       runWithoutTracking<T>(f: () => T): Promise<T> {
         return super.withoutTracking(f);
       }
+
+      protected getParameterFormDescs() {
+        const base = super.getParameterFormDescs();
+        return [
+          ...base,
+          ...that.getParameterFormDescs()
+        ];
+      }
     }
 
     this.ranking = new EmbeddedRankingView(context, selection, this.node, options);
@@ -182,6 +191,15 @@ export abstract class AEmbeddedRanking<T extends IRow> implements IViewProvider 
     if (this.ranking) {
       this.ranking.update();
     }
+  }
+
+  /**
+   * return a list of FormBuilder element descriptions to build the parameter form
+   * @returns {IFormElementDesc[]}
+   */
+  protected getParameterFormDescs(): IFormElementDesc[] {
+    // hook
+    return [];
   }
 }
 


### PR DESCRIPTION
closes #228 

this PR adds support for the `getParameterFormDescs` method as available in `AView`.

AEmbeddedRanking is used as a wrapper around an `ARankingView` (AEmbeddedRanking instantiates an `EmbeddedRanking` which inherits from `ARankingView`) to be able to embed it directly at the start of an application workflow (without inputSelection, as opposed to a detail view --> like the RankingView in Ordino)

Long story short: AEmbeddedRanking contains a nested class `EmbeddedRanking` which inherits from `ARankingView`, however `getParameterFormDescs` is not forwarded to the nested class.

This PR adds the `getParameterFormDescs` method to AEmbeddedRanking and calls it in the overriddden `getParameterFormDescs` from `EmbeddedRanking`