### PR TITLE
Enable AView to process 1:n mappings by id and by name

### DIFF
--- a/src/views/AView.ts
+++ b/src/views/AView.ts
@@ -12,7 +12,7 @@ import {
   EViewMode, ISelection, isSameSelection, IView, IViewContext, VIEW_EVENT_ITEM_SELECT,
   VIEW_EVENT_LOADING_FINISHED, VIEW_EVENT_UPDATE_ENTRY_POINT, VIEW_EVENT_UPDATE_SHARED
 } from './interfaces';
-import {resolveIds, resolveAllNames, resolveAllIds} from './resolve';
+import {resolveIds, resolveAllNames, resolveAllIds, resolveNames} from './resolve';
 import {DEFAULT_SELECTION_NAME} from '../extensions';
 import {IForm} from '../form/interfaces';
 
@@ -271,7 +271,7 @@ export abstract class AView extends EventHandler implements IView {
    * @returns {Promise<string[]>}
    */
   protected resolveSelectionByName(idType = this.idType): Promise<string[]> {
-    return resolveIds(this.selection.idtype, this.selection.range, idType);
+    return resolveNames(this.selection.idtype, this.selection.range, idType);
   }
 
    /**

--- a/src/views/AView.ts
+++ b/src/views/AView.ts
@@ -12,7 +12,7 @@ import {
   EViewMode, ISelection, isSameSelection, IView, IViewContext, VIEW_EVENT_ITEM_SELECT,
   VIEW_EVENT_LOADING_FINISHED, VIEW_EVENT_UPDATE_ENTRY_POINT, VIEW_EVENT_UPDATE_SHARED
 } from './interfaces';
-import {resolveIds} from './resolve';
+import {resolveIds, resolveAllNames, resolveAllIds} from './resolve';
 import {DEFAULT_SELECTION_NAME} from '../extensions';
 import {IForm} from '../form/interfaces';
 
@@ -259,12 +259,38 @@ export abstract class AView extends EventHandler implements IView {
   }
 
   /**
-   * resolve the name of the current input selection
+   * resolve the id of the current input selection
    * @returns {Promise<string[]>}
    */
   protected resolveSelection(idType = this.idType): Promise<string[]> {
     return resolveIds(this.selection.idtype, this.selection.range, idType);
   }
+
+  /**
+   * resolve the name of the current input selection
+   * @returns {Promise<string[]>}
+   */
+  protected resolveSelectionByName(idType = this.idType): Promise<string[]> {
+    return resolveIds(this.selection.idtype, this.selection.range, idType);
+  }
+
+   /**
+   * resolves the ids of the current input selection to all 1:n related names, not just the first one like resolveSelection does
+   * @returns {Promise<string[]>}
+   */
+  protected resolveMultipleSelections(idType = this.idType): Promise<string[][]> {
+    return resolveAllIds(this.selection.idtype, this.selection.range, idType);
+  }
+
+  /**
+   * resolves the names of the current input selection to all 1:n related names, not just the first one like resolveSelection does
+   * @returns {Promise<string[]>}
+   */
+  protected resolveMultipleSelectionsByName(idType = this.idType): Promise<string[][]> {
+    return resolveAllNames(this.selection.idtype, this.selection.range, idType);
+  }
+
+
 
   setItemSelection(selection: ISelection, name: string = DEFAULT_SELECTION_NAME) {
     const current = this.itemSelections.get(name);

--- a/src/views/AView.ts
+++ b/src/views/AView.ts
@@ -277,7 +277,7 @@ export abstract class AView extends EventHandler implements IView {
   /**
    * resolves the ids of the current input selection to all 1:n related names, not just the first one like resolveSelection does
    * @returns {Promise<string[]>}
-  */
+   */
   protected resolveMultipleSelections(idType = this.idType): Promise<string[][]> {
     return resolveAllIds(this.selection.idtype, this.selection.range, idType);
   }

--- a/src/views/AView.ts
+++ b/src/views/AView.ts
@@ -116,7 +116,7 @@ export abstract class AView extends EventHandler implements IView {
     const descs = this.getParameterFormDescs().map((d) => Object.assign({}, d));
 
 
-    const onInit: (name: string, value: any, previousValue: any, isInitialzation: boolean)=>void = <any>onParameterChange;
+    const onInit: (name: string, value: any, previousValue: any, isInitialzation: boolean) => void = <any>onParameterChange;
 
     // map FormElement change function to provenance graph onChange function
     descs.forEach((p) => {
@@ -274,10 +274,10 @@ export abstract class AView extends EventHandler implements IView {
     return resolveNames(this.selection.idtype, this.selection.range, idType);
   }
 
-   /**
+  /**
    * resolves the ids of the current input selection to all 1:n related names, not just the first one like resolveSelection does
    * @returns {Promise<string[]>}
-   */
+  */
   protected resolveMultipleSelections(idType = this.idType): Promise<string[][]> {
     return resolveAllIds(this.selection.idtype, this.selection.range, idType);
   }

--- a/src/views/resolve.ts
+++ b/src/views/resolve.ts
@@ -33,3 +33,38 @@ export function resolveIds(fromIDType: IDType, ids: Range | number[], toIDType: 
   // assume mappable
   return fromIDType.mapToFirstName(ids, target);
 }
+
+export function resolveNames(fromIDType: IDType, ids: Range | number[], toIDType: IDType | string = null): Promise<string[]> {
+  const target = toIDType === null ? fromIDType : resolve(toIDType);
+  if (fromIDType.id === target.id) {
+    // same just unmap to name
+    return fromIDType.unmap(ids);
+  }
+  // assume mappable
+  return fromIDType.unmap(ids).then((names) => {
+    return fromIDType.mapNameToFirstName(names, target);
+  });
+
+}
+
+export function resolveAllNames(fromIDType: IDType, ids: Range | number[], toIDType: IDType | string = null): Promise<string[][]> {
+  const target = toIDType === null ? fromIDType : resolve(toIDType);
+  if (fromIDType.id === target.id) {
+    // same just unmap to name
+    return fromIDType.unmap(ids).then((ids) => [ids]);
+  }
+  // assume mappable
+  return fromIDType.unmap(ids).then((names) => {
+    return fromIDType.mapNameToName(names, target);
+  });
+}
+
+export function resolveAllIds(fromIDType: IDType, ids: Range | number[], toIDType: IDType | string = null): Promise<string[][]> {
+  const target = toIDType === null ? fromIDType : resolve(toIDType);
+  if (fromIDType.id === target.id) {
+    // same just unmap to name
+    return fromIDType.unmap(ids).then((ids) => [ids]);
+  }
+  // assume mappable
+  return fromIDType.mapToName(ids, target);
+}

--- a/src/views/resolve.ts
+++ b/src/views/resolve.ts
@@ -13,6 +13,14 @@ export function resolveIdToNames(fromIDType: IDType, id: number, toIDType: IDTyp
   return fromIDType.mapToName([id], target).then((names) => names);
 }
 
+/**
+ * Maps exactly one _id (numeric id) of the fromIDtype to the first occurrence of the toIDtype
+ *
+ * @param fromIDType The IDType to map from
+ * @param id The current _id
+ * @param toIDtype The IDType to map to
+ * @returns a Promise to the matching id of the toIDtype
+ */
 export function resolveId(fromIDType: IDType, id: number, toIDtype: IDType | string = null): Promise<string> {
   const target = toIDtype === null ? fromIDType : resolve(toIDtype);
   if (fromIDType.id === target.id) {
@@ -24,6 +32,14 @@ export function resolveId(fromIDType: IDType, id: number, toIDtype: IDType | str
   return fromIDType.mapToFirstName([id], target).then((names) => names[0]);
 }
 
+/**
+ * Maps numerous _ids (numeric ids) of the fromIDtype to each first occurrence of the toIDtype
+ *
+ * @param fromIDType The IDType to map from
+ * @param ids The current _ids
+ * @param toIDtype The IDType to map to
+ * @returns a Promise to the matching id of the toIDtype
+ */
 export function resolveIds(fromIDType: IDType, ids: Range | number[], toIDType: IDType | string = null): Promise<string[]> {
   const target = toIDType === null ? fromIDType : resolve(toIDType);
   if (fromIDType.id === target.id) {
@@ -34,6 +50,14 @@ export function resolveIds(fromIDType: IDType, ids: Range | number[], toIDType: 
   return fromIDType.mapToFirstName(ids, target);
 }
 
+/**
+ * Maps numerous ids (named ids) of the fromIDtype to each first occurrence of the toIDtype
+ *
+ * @param fromIDType The IDType to map from
+ * @param ids The current _ids
+ * @param toIDtype The IDType to map to
+ * @returns a Promise to the matching id of the toIDtype
+ */
 export function resolveNames(fromIDType: IDType, ids: Range | number[], toIDType: IDType | string = null): Promise<string[]> {
   const target = toIDType === null ? fromIDType : resolve(toIDType);
   if (fromIDType.id === target.id) {
@@ -47,6 +71,15 @@ export function resolveNames(fromIDType: IDType, ids: Range | number[], toIDType
 
 }
 
+/**
+ * Maps numerous ids (named ids) of the fromIDtype to all occurrence of the toIDtype
+ * This can resolve a n:m mapping
+ *
+ * @param fromIDType The IDType to map from
+ * @param ids The current _ids
+ * @param toIDtype The IDType to map to
+ * @returns a Promise to the matching id of the toIDtype
+ */
 export function resolveAllNames(fromIDType: IDType, ids: Range | number[], toIDType: IDType | string = null): Promise<string[][]> {
   const target = toIDType === null ? fromIDType : resolve(toIDType);
   if (fromIDType.id === target.id) {
@@ -59,6 +92,15 @@ export function resolveAllNames(fromIDType: IDType, ids: Range | number[], toIDT
   });
 }
 
+/**
+ * Maps numerous _ids (numeric ids) of the fromIDtype to all occurrence of the toIDtype
+ * This can resolve a n:m mapping
+ *
+ * @param fromIDType The IDType to map from
+ * @param ids The current _ids
+ * @param toIDtype The IDType to map to
+ * @returns a Promise to the matching id of the toIDtype
+ */
 export function resolveAllIds(fromIDType: IDType, ids: Range | number[], toIDType: IDType | string = null): Promise<string[][]> {
   const target = toIDType === null ? fromIDType : resolve(toIDType);
   if (fromIDType.id === target.id) {


### PR DESCRIPTION
Closes #230 

### Summary

The resolveSelection method of AView internally relies on the numeric _id value and only maps to the first targetIdType element. This value is not always known to external MappingProviders. So a mapping by name is also needed. Additionally, the AView is now also able to resolve 1:n mappings and not just 1:1 mappings.

This change causes a new minor version.