### PR TITLE
Add LineUp column patcher extension

### DIFF
--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -15,7 +15,6 @@ export * from './tour/extensions';
 export const EXTENSION_POINT_TDP_SCORE = 'tdpScore';
 export const EXTENSION_POINT_TDP_SCORE_IMPL = 'tdpScoreImpl';
 export const EXTENSION_POINT_TDP_SCORE_LOADER = 'tdpScoreLoader';
-export const EXTENSION_POINT_TDP_SCORE_COLUMN_PATCHER = 'tdpScoreColumnPatcher';
 export const EXTENSION_POINT_TDP_RANKING_BUTTON = 'tdpRankingButton';
 export const EXTENSION_POINT_TDP_VIEW = 'tdpView';
 export const EXTENSION_POINT_TDP_INSTANT_VIEW = 'tdpInstantView';
@@ -112,7 +111,19 @@ export interface IScoreLoaderExtensionDesc extends IPluginDesc {
   load(): Promise<IPlugin & IScoreLoaderExtension>;
 }
 
+export const EP_TDP_CORE_SCORE_COLUMN_PATCHER = 'epTdpCoreScoreColumnPatcher';
+
+/**
+ * Extension to patch a LineUp column generated as score.
+ */
 export interface IScoreColumnPatcherExtension {
+  /**
+   * Patcher function called for every column to patch.
+   * @param pluginDesc Description of the plugin.
+   * @param colDesc Description of the column.
+   * @param rows Rows from the score.
+   * @param col Column to patch.
+   */
   factory(pluginDesc: IPluginDesc, colDesc: IAdditionalColumnDesc, rows: IScoreRow<any>[], col: Column): Promise<void>;
 }
 

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -3,10 +3,10 @@ import {IUser} from 'phovea_core/src/security';
 import {IObjectRef, ProvenanceGraph} from 'phovea_core/src/provenance';
 import Range from 'phovea_core/src/range/Range';
 import {IEventHandler} from 'phovea_core/src/event';
-import {IScore} from './lineup';
+import {IScore, IAdditionalColumnDesc} from './lineup';
 import {RangeLike} from 'phovea_core/src/range';
 import {IDType} from 'phovea_core/src/idtype';
-import {IColumnDesc} from 'lineupjs';
+import {IColumnDesc, Column} from 'lineupjs';
 import {EViewMode} from './views/interfaces';
 import {AppHeader} from 'phovea_ui/src/header';
 
@@ -15,6 +15,7 @@ export * from './tour/extensions';
 export const EXTENSION_POINT_TDP_SCORE = 'tdpScore';
 export const EXTENSION_POINT_TDP_SCORE_IMPL = 'tdpScoreImpl';
 export const EXTENSION_POINT_TDP_SCORE_LOADER = 'tdpScoreLoader';
+export const EXTENSION_POINT_TDP_SCORE_COLUMN_PATCHER = 'tdpScoreColumnPatcher';
 export const EXTENSION_POINT_TDP_RANKING_BUTTON = 'tdpRankingButton';
 export const EXTENSION_POINT_TDP_VIEW = 'tdpView';
 export const EXTENSION_POINT_TDP_INSTANT_VIEW = 'tdpInstantView';
@@ -109,6 +110,14 @@ export interface IScoreLoaderExtensionDesc extends IPluginDesc {
   idtype: string;
 
   load(): Promise<IPlugin & IScoreLoaderExtension>;
+}
+
+export interface IScoreColumnPatcherExtension {
+  factory(pluginDesc: IPluginDesc, colDesc: IAdditionalColumnDesc, rows: IScoreRow<any>[], col: Column): Promise<void>;
+}
+
+export interface IScoreColumnPatcherExtensionDesc extends IPluginDesc {
+  load(): Promise<IPlugin & IScoreColumnPatcherExtension>;
 }
 
 export interface IRankingButtonExtension {

--- a/src/lineup/internal/column.ts
+++ b/src/lineup/internal/column.ts
@@ -3,9 +3,10 @@
  */
 import {IDataProvider, IColumnDesc, ScaleMappingFunction, ValueColumn, NumberColumn, BoxPlotColumn, NumbersColumn, Column, CategoricalColumn, toCategories} from 'lineupjs';
 import {createAccessor} from './utils';
-import {IScoreRow} from '../../extensions';
+import {IScoreRow, EXTENSION_POINT_TDP_SCORE_COLUMN_PATCHER, IScoreColumnPatcherExtensionDesc} from '../../extensions';
 import {showErrorModalDialog} from '../../dialogs';
 import {extent, min, max} from 'd3';
+import {list as listPlugins} from 'phovea_core/src/plugin';
 
 
 function extentByType(type: string, rows: any, acc: (d: any) => any): [number, number] {
@@ -54,9 +55,9 @@ export function addLazyColumn(colDesc: any, data: Promise<IScoreRow<any>[]>, pro
     });
 
   // success
-  const loaded = data.then((rows: IScoreRow<any>[]) => {
+  const loaded = data.then(async (rows: IScoreRow<any>[]) => {
     accessor.setRows(rows);
-    patchColumn(colDesc, rows, col);
+    await patchColumn(colDesc, rows, col);
     markLoaded(provider, colDesc, true);
 
     if (done) {
@@ -71,11 +72,11 @@ export function addLazyColumn(colDesc: any, data: Promise<IScoreRow<any>[]>, pro
 
     newData.catch(showErrorModalDialog);
     // success
-    return newData.then((rows: IScoreRow<any>[]) => {
-        accessor.setRows(rows);
-        patchColumn(colDesc, rows, col);
-        markLoaded(provider, colDesc, true);
-        return col;
+    return newData.then(async (rows: IScoreRow<any>[]) => {
+      accessor.setRows(rows);
+      await patchColumn(colDesc, rows, col);
+      markLoaded(provider, colDesc, true);
+      return col;
     });
   };
 
@@ -94,7 +95,7 @@ function markLoaded(provider: IDataProvider, colDesc: any, loaded: boolean) {
   (<any>colDesc).lazyLoaded = !loaded;
 }
 
-function patchColumn(colDesc: any, rows: IScoreRow<any>[], col: Column) {
+async function patchColumn(colDesc: any, rows: IScoreRow<any>[], col: Column): Promise<void> {
   if (colDesc.type === 'number' || colDesc.type === 'boxplot' || colDesc.type === 'numbers') {
     const ncol = <NumberColumn | BoxPlotColumn | NumbersColumn>col;
     if (!(colDesc.constantDomain) || (colDesc.constantDomain === 'max' || colDesc.constantDomain === 'min')) { //create a dynamic range if not fixed
@@ -134,4 +135,10 @@ function patchColumn(colDesc: any, rows: IScoreRow<any>[], col: Column) {
     ccol.lookup.clear();
     categories.forEach((c) => ccol.lookup.set(c.name, c));
   }
+
+  // Await all patchers to complete before returning
+  await Promise.all(listPlugins(EXTENSION_POINT_TDP_SCORE_COLUMN_PATCHER).map(async (pluginDesc: IScoreColumnPatcherExtensionDesc) => {
+    const plugin = await pluginDesc.load();
+    plugin.factory(pluginDesc, colDesc, rows, col);
+  }));
 }

--- a/src/lineup/internal/column.ts
+++ b/src/lineup/internal/column.ts
@@ -3,7 +3,7 @@
  */
 import {IDataProvider, IColumnDesc, ScaleMappingFunction, ValueColumn, NumberColumn, BoxPlotColumn, NumbersColumn, Column, CategoricalColumn, toCategories} from 'lineupjs';
 import {createAccessor} from './utils';
-import {IScoreRow, EXTENSION_POINT_TDP_SCORE_COLUMN_PATCHER, IScoreColumnPatcherExtensionDesc} from '../../extensions';
+import {IScoreRow, EP_TDP_CORE_SCORE_COLUMN_PATCHER, IScoreColumnPatcherExtensionDesc} from '../../extensions';
 import {showErrorModalDialog} from '../../dialogs';
 import {extent, min, max} from 'd3';
 import {list as listPlugins} from 'phovea_core/src/plugin';
@@ -137,7 +137,7 @@ async function patchColumn(colDesc: any, rows: IScoreRow<any>[], col: Column): P
   }
 
   // Await all patchers to complete before returning
-  await Promise.all(listPlugins(EXTENSION_POINT_TDP_SCORE_COLUMN_PATCHER).map(async (pluginDesc: IScoreColumnPatcherExtensionDesc) => {
+  await Promise.all(listPlugins(EP_TDP_CORE_SCORE_COLUMN_PATCHER).map(async (pluginDesc: IScoreColumnPatcherExtensionDesc) => {
     const plugin = await pluginDesc.load();
     plugin.factory(pluginDesc, colDesc, rows, col);
   }));


### PR DESCRIPTION
See #233 for a more information on the problem and why we need to solve it. 

**Usage** 
The column patcher is a simple function, included as extension point with the type `tdpScoreColumnPatcher`. The following example would modify an (already internally patched) `NumberColumn` score. The actual use case is to patch your own column, which is only accessible from within an app and has an known interface (with methods such as `setCategories(...)`). 

1. Add the extension to your `phovea.ts`: 
```
  registry.push('tdpScoreColumnPatcher', 'another-number-column-patcher', () => System.import('./patcher/AnotherNumberColumnPatcher'), {
    factory: 'patchColumn'
  });
```
2. As we have defined the `factory: 'patchColumn'`, we have to create the file `./patcher/AnotherNumberColumnPatcher.ts` with an exported function `patchColumn`. 
```
export function patchColumn(pluginDesc: IPluginDesc, colDesc: IAdditionalColumnDesc, rows: IScoreRow<any>[], col: Column) {
  if (colDesc.type === 'number' && col instanceof NumberColumn) {
    // Calculate something using the rows, and set it on the column...
  }
}
```
3. Now, each time a score is loaded, your patcher will be called (after the internal patching) to allow your updates to take place. 