### PR TITLE
Fix write access for public sessions

### DIFF
--- a/src/SessionList.ts
+++ b/src/SessionList.ts
@@ -73,10 +73,10 @@ abstract class ASessionList {
     });
     $enter.select('a[data-action="select"]').on('click', (d) => {
       stopEvent();
-      if (!canWrite(d)) {
-        manager.cloneLocal(d);
-      } else {
+      if (canWrite(d)) {
         manager.loadGraph(d);
+      } else {
+        manager.cloneLocal(d);
       }
       return false;
     });

--- a/src/SessionList.ts
+++ b/src/SessionList.ts
@@ -308,11 +308,19 @@ export class PersistentSessionList extends ASessionList {
         {
           const $tr = $parent.select('#session_others tbody').selectAll('tr').data(otherworkspaces);
 
-          const $trEnter = $tr.enter().append('tr').html(`
-              <td></td>
-              <td></td>
-              <td></td>
-              <td>${ASessionList.createButton('clone')}</td>`);
+          const $trEnter = $tr.enter().append('tr').html((d) => {
+            let actions = '';
+            if(canWrite(d)) {
+              actions += ASessionList.createButton('select');
+            }
+            actions += ASessionList.createButton('clone');
+
+            return `
+            <td></td>
+            <td></td>
+            <td></td>
+            <td>${actions}</td>`;
+          });
 
           this.registerActionListener(manager, $trEnter);
           $tr.select('td').text((d) => d.name);
@@ -345,11 +353,19 @@ export class PersistentSessionList extends ASessionList {
         {
           const $tr = $parent.select('#session_others').selectAll('div').data(otherworkspaces);
 
-          const $trEnter = $tr.enter().append('div').classed('sessionEntry', true).html(`
+          const $trEnter = $tr.enter().append('div').classed('sessionEntry', true).html((d) => {
+            let actions = '';
+            if(canWrite(d)) {
+              actions += ASessionList.createButton('select');
+            }
+            actions += ASessionList.createButton('clone');
+
+            return `
               <span></span>
               <span></span>
               <span></span>
-              <span>${ASessionList.createButton('clone')}</span>`);
+              <span>${actions}</span>`;
+          });
 
           this.registerActionListener(manager, $trEnter);
           $tr.select('span').text((d) => d.name);


### PR DESCRIPTION
Closes #176 

### Summary 

Independent of the granted permissions users were only allowed to clone a persistent session. Now, the write permission is checked and the select button is displayed. For read permission only the select button is not shown.

### Test

1. Created three sessions:
   * Session shared with zen_austin as buddy
     ![grafik](https://user-images.githubusercontent.com/5851088/68482247-6b036f00-0239-11ea-90cc-4e4533b730bf.png)
   * Public session everyone can write
     ![grafik](https://user-images.githubusercontent.com/5851088/68482279-7d7da880-0239-11ea-9c8e-06de7d75b159.png)
   * Public session everyone can read
     ![grafik](https://user-images.githubusercontent.com/5851088/68482340-a30ab200-0239-11ea-9e40-bddd3129c4e7.png)
2. Login as user _zen_austin_
3. Open the persistent session section
  ![grafik](https://user-images.githubusercontent.com/5851088/68482147-3394c280-0239-11ea-8b97-5c08c8ef1a31.png)


