### PR TITLE
Added options to LineUpPanelAction to make it more configurable

### DIFF
--- a/src/lineup/ARankingView.ts
+++ b/src/lineup/ARankingView.ts
@@ -57,15 +57,78 @@ export interface IARankingViewOptions {
    * @default true
    */
   enableOverviewMode: boolean | 'active';
+
   /**
    * enable zoom button
    * @default true
    */
   enableZoom: boolean;
 
+  /**
+   * enable download data button
+   * @default true
+   */
+  enableDownload: boolean;
+
+  /**
+   * enable save list of entities button
+   * @default true
+   */
+  enableSaveRanking: boolean;
+
+  /**
+   * enable collapsing button of side panel
+   * @default true
+   */
+  enableSidePanelCollapsing: boolean;
+
+  /**
+   * enable side panel
+   * @default 'collapsed'
+   */
   enableSidePanel: boolean | 'collapsed' | 'top';
 
+  /**
+   * enable add columns button
+   * @default true
+   */
   enableAddingColumns: boolean;
+
+  /**
+   * enable support columns in the add column dialog
+   * @default true
+   */
+  enableAddingSupportColumns: boolean;
+
+  /**
+   * enable combining columns in the add column dialog
+   * @default true
+   */
+  enableAddingCombiningColumns: boolean;
+
+  /**
+   * enable score columns in the add column dialog
+   * @default true
+   */
+  enableAddingScoreColumns: boolean;
+
+  /**
+   * enable previously created columns in the add column dialog
+   * @default true
+   */
+  enableAddingPreviousColumns: boolean;
+
+  /**
+   * enable database columns in the add column dialog
+   * @default true
+   */
+  enableAddingDatabaseColumns: boolean;
+
+  /**
+   * enable meta data score columns in the add column dialog
+   * @default true
+   */
+  enableAddingMetaDataColumns: boolean;
 
   enableHeaderSummary: boolean;
 
@@ -143,8 +206,17 @@ export abstract class ARankingView extends AView {
     subType: {key: '', value: ''},
     enableOverviewMode: true,
     enableZoom: true,
+    enableDownload: true,
+    enableSaveRanking: true,
     enableAddingColumns: true,
     enableAddingColumnGrouping: false,
+    enableAddingSupportColumns: true,
+    enableAddingCombiningColumns: true,
+    enableAddingScoreColumns: true,
+    enableAddingPreviousColumns: true,
+    enableAddingDatabaseColumns: true,
+    enableAddingMetaDataColumns: true,
+    enableSidePanelCollapsing: true,
     enableSidePanel: 'collapsed',
     enableHeaderSummary: true,
     enableStripedBackground: false,


### PR DESCRIPTION
Added options such as `enableDownload` to show/hide the download button in the side panel. 
Additionally, options to configure the chooser were added such as `enableAddingSupportColumns, ...`.

@thinkh Personally, I would collect the configuration keys under a specific key, such as `panelActions` for the buttons or the `Add Column` dialog. Otherwise, with more options coming, we will clutter it with `enable...` entries. What is your thought on this? 