### PR TITLE
check if arguments are present

### DIFF
--- a/tdp_core/db.py
+++ b/tdp_core/db.py
@@ -265,10 +265,11 @@ def prepare_arguments(view, config, replacements=None, arguments=None, extra_sql
     for arg in view.arguments:
       info = view.get_argument_info(arg)
       lookup_key = arg
+
       if lookup_key not in arguments:
-        if (arg + u'[]') in arguments:
+        if (arg + u'[]') in arguments:  # check if we can find the lookup key with array form
           lookup_key = (arg + u'[]')
-        elif not info or not info.list_as_tuple:
+        else:
           _log.warn(u'missing argument "%s": "%s"', view.query, arg)
           abort(400, u'missing argument: ' + arg)
       parser = info.type if info and info.type is not None else lambda x: x

--- a/tdp_core/db.py
+++ b/tdp_core/db.py
@@ -269,7 +269,7 @@ def prepare_arguments(view, config, replacements=None, arguments=None, extra_sql
       if lookup_key not in arguments:
         if (arg + u'[]') in arguments:  # check if we can find the lookup key with array form
           lookup_key = (arg + u'[]')
-        else:
+        elif not info or not info.list_as_tuple:
           _log.warn(u'missing argument "%s": "%s"', view.query, arg)
           abort(400, u'missing argument: ' + arg)
       parser = info.type if info and info.type is not None else lambda x: x
@@ -278,7 +278,7 @@ def prepare_arguments(view, config, replacements=None, arguments=None, extra_sql
           vs = arguments.getlist(lookup_key) if hasattr(arguments, 'getlist') else arguments.get(lookup_key)
           value = tuple([parser(v) for v in vs])  # multi values need to be a tuple not a list
         elif info and info.list_as_tuple:
-          vs = arguments.getlist(lookup_key) if hasattr(arguments, 'getlist') else arguments.get(lookup_key)
+          vs = arguments.getlist(lookup_key) if hasattr(arguments, 'getlist') else arguments.get(lookup_key, [])
           if len(vs) == 0:
             value = "(1, null)"
           else:


### PR DESCRIPTION
this basically undoes the latest changes in the following line: https://github.com/datavisyn/tdp_core/blob/master/tdp_core/db.py#L271

@anita-steiner , I'm currently not sure why these changes were for. undoing it worked in my tests. if we need to `not info or not info.list_as_tuple` check I can undo my changes and add an else branch to this conditional. however I think just aborting the request as we have no given parameters for the required argument makes sense