### PR TITLE
Fixed incorrect overload typing in addTrackedScoreColumn

### DIFF
--- a/src/base/AEmbeddedRanking.ts
+++ b/src/base/AEmbeddedRanking.ts
@@ -173,8 +173,8 @@ export abstract class AEmbeddedRanking<T extends IRow> implements IViewProvider 
     return this.ranking.runWithoutTracking(() => f(this.data));
   }
 
-  protected addTrackedScoreColumn(scoreId: string, scoreParams: any, position?: number): Promise<ILazyLoadedColumn>;
-  protected addTrackedScoreColumn(score: IScore<any>, position?: number): Promise<ILazyLoadedColumn[]>;
+  protected addTrackedScoreColumn(scoreId: string, scoreParams: any, position?: number): Promise<ILazyLoadedColumn[]>;
+  protected addTrackedScoreColumn(score: IScore<any>, position?: number): Promise<ILazyLoadedColumn>;
   protected addTrackedScoreColumn(score: IScore<any> | string, scoreParams: any, position?: number): Promise<ILazyLoadedColumn|ILazyLoadedColumn[]> {
     if (typeof score !== 'string') {
       return this.ranking.addTrackedScoreColumn(score, scoreParams); // aka scoreParams = position


### PR DESCRIPTION
The previous PR regarding this topic (https://github.com/datavisyn/tdp_core/pull/267) introduced a small bug in the `addTrackedScoreColumn`, as the return value if a `string` is passed as first argument is actually an array (in a promise). Currently, it is set to be the other way around. 