### PR TITLE
Added no_cache option to DBViewBuilder

### DIFF
--- a/tdp_core/dbview.py
+++ b/tdp_core/dbview.py
@@ -45,6 +45,7 @@ class DBView(object):
     self.table = None
     self.security = None
     self.assign_ids = False
+    self.no_cache = False
 
   def needs_to_fill_up_columns(self):
     return self.columns_filled_up is False and self.table is not None
@@ -62,6 +63,7 @@ class DBView(object):
       r['filters'] = list(self.filters.keys())
     if self.queries:
       r['queries'] = {k: clean_query(v) for k, v in self.queries.items()}
+    r['no_cache'] = self.no_cache
     return r
 
   def is_valid_filter(self, key):
@@ -177,6 +179,7 @@ class DBViewBuilder(object):
     self.v.filters = view.filters.copy()
     self.v.valid_replacements = view.valid_replacements.copy()
     self.v.security = view.security
+    self.v.no_cache = view.no_cache
     return self
 
   def description(self, desc, summary=None):
@@ -374,6 +377,13 @@ class DBViewBuilder(object):
     :return: self
     """
     self.v.security = security_check
+    return self
+
+  def no_cache(self):
+    """
+    adds a no-cache header to the response to avoid client caching of the response
+    """
+    self.v.no_cache = True
     return self
 
   def build(self):

--- a/tdp_core/sql.py
+++ b/tdp_core/sql.py
@@ -1,10 +1,11 @@
-from phovea_server.ns import Namespace, request, abort
+from phovea_server.ns import Namespace, request, abort, no_cache
 from . import db
 from .utils import map_scores
 from phovea_server.util import jsonify
 from .security import tdp_login_required
 from .formatter import formatter
 import logging
+from functools import wraps
 
 __author__ = 'Samuel Gratzl'
 _log = logging.getLogger(__name__)
@@ -16,6 +17,21 @@ def load_ids(idtype, mapping):
 
   manager = phovea_server.plugin.lookup('idmanager')
   manager.load(idtype, mapping)
+
+
+def _view_no_cache(func):
+  """
+  wrap the function in no_cache if the view identified by view_name has the no_cache flag set
+  """
+  @wraps(func)
+  def decorated_view(*args, **kwargs):
+    if kwargs.get('view_name', None) is not None and kwargs.get('database', None) is not None:
+      view_name, _ = formatter(kwargs['view_name'])
+      config, _, view = db.resolve_view(kwargs['database'], view_name)
+      if view.no_cache:
+        return no_cache(func)(*args, **kwargs)
+    return func(*args, **kwargs)
+  return decorated_view
 
 
 @app.route('/')
@@ -49,6 +65,7 @@ def _return_query():
 @app.route('/<database>/<view_name>', methods=['GET', 'POST'])
 @app.route('/<database>/<view_name>/filter', methods=['GET', 'POST'])
 @tdp_login_required
+@_view_no_cache
 def get_filtered_data(database, view_name):
   """
   version of getting data in which the arguments starting with `filter_` are used to build a where clause
@@ -71,6 +88,7 @@ def get_filtered_data(database, view_name):
 
 @app.route('/<database>/<view_name>/score', methods=['GET', 'POST'])
 @tdp_login_required
+@_view_no_cache
 def get_score_data(database, view_name):
   """
   version of getting data like filter with additional mapping of score entries
@@ -99,6 +117,7 @@ def get_score_data(database, view_name):
 
 @app.route('/<database>/<view_name>/count', methods=['GET', 'POST'])
 @tdp_login_required
+@_view_no_cache
 def get_count_data(database, view_name):
   """
   similar to the /filter clause but returns the count of results instead of the rows itself
@@ -117,6 +136,7 @@ def get_count_data(database, view_name):
 
 @app.route('/<database>/<view_name>/desc')
 @tdp_login_required
+@_view_no_cache
 def get_desc(database, view_name):
   view_name, _ = formatter(view_name)
   config, _, view = db.resolve_view(database, view_name)
@@ -125,6 +145,7 @@ def get_desc(database, view_name):
 
 @app.route('/<database>/<view_name>/lookup', methods=['GET', 'POST'])
 @tdp_login_required
+@_view_no_cache
 def lookup(database, view_name):
   """
   Does the same job as search, but paginates the result set


### PR DESCRIPTION
When the `no_cache()` option is called when building a view via `DBViewBuilder`, it will add a `no_cache` decorator to the function response causing the client to stop caching of this specific request. 