### PR TITLE
Configurable query delay for Select3

### DIFF
--- a/src/form/elements/Select3.ts
+++ b/src/form/elements/Select3.ts
@@ -147,6 +147,12 @@ export interface ISelect3Options<T extends Readonly<IdTextPair>> {
    * @default ' '
    */
   defaultTokenSeparator: string;
+
+  /**
+   * query delay
+   * @default 250
+   */
+  queryDelay: number;
 }
 
 /**
@@ -198,7 +204,8 @@ export default class Select3<T extends IdTextPair> extends EventHandler {
     tokenSeparators: /[\s\n\r;,]+/gm,
     defaultTokenSeparator: ' ',
     id: null,
-    name: null
+    name: null,
+    queryDelay: 250
   };
 
   private readonly select2Options: Select2Options = <any>{
@@ -213,7 +220,7 @@ export default class Select3<T extends IdTextPair> extends EventHandler {
     ajax: {
       url: '',
       dataType: 'json',
-      delay: 250,
+      delay: this.options.queryDelay,
       cache: true,
       transport: this.searchImpl.bind(this)
     }
@@ -238,13 +245,20 @@ export default class Select3<T extends IdTextPair> extends EventHandler {
 
   constructor(options: Partial<ISelect3Options<T>> = {}) {
     super();
+    // merge the default options with the given options
     Object.assign(this.options, options);
+
+    // merge our default select2Options
     Object.assign(this.select2Options, {
       width: this.options.width,
       minimumInputLength: this.options.minimumInputLength,
       multiple: this.options.multiple,
       placeholder: this.options.placeholder,
-      tags: Boolean(this.options.validate) // only if a validate method is there
+      tags: Boolean(this.options.validate), // only if a validate method is there
+      ajax: Object.assign({}, { // also override ajax options
+        delay: this.options.queryDelay,
+        cache: this.options.cacheResults
+      })
     });
 
     this.node = this.options.document.createElement('div');

--- a/src/form/elements/Select3.ts
+++ b/src/form/elements/Select3.ts
@@ -255,9 +255,8 @@ export default class Select3<T extends IdTextPair> extends EventHandler {
       multiple: this.options.multiple,
       placeholder: this.options.placeholder,
       tags: Boolean(this.options.validate), // only if a validate method is there
-      ajax: Object.assign({}, { // also override ajax options
-        delay: this.options.queryDelay,
-        cache: this.options.cacheResults
+      ajax: Object.assign(this.select2Options.ajax, { // also override ajax options
+        delay: this.options.queryDelay
       })
     });
 

--- a/src/form/elements/Select3.ts
+++ b/src/form/elements/Select3.ts
@@ -149,7 +149,7 @@ export interface ISelect3Options<T extends Readonly<IdTextPair>> {
   defaultTokenSeparator: string;
 
   /**
-   * query delay
+   * Configures the time span how long to wait after a user has stopped typing before sending the AJAX request.
    * @default 250
    */
   queryDelay: number;


### PR DESCRIPTION
The delay when typing into a Select3 box is now configurable, i.e. the delay after the last character has been typed and before the search method of Select2 is called

do we want other Select2 options to be overridden?

for the AJAX options:
- I thought the `cache` option would be good to be configurable, however Select3 builds its own cache
- as far as I can see the URL is never needed, because the the search is performed by the `search` option, which is a function performing the search
- dataType: always JSON?
- transport: Select3's search function 