### PR TITLE
Fix date values in language strings

### DIFF
--- a/src/assets/locales/en/tdp.json
+++ b/src/assets/locales/en/tdp.json
@@ -86,9 +86,9 @@
       "hour": "an hour ago",
       "hour_plural": "{{count}} hours ago",
       "day": "a day ago",
-      "day_plural": "{{}} days ago",
+      "day_plural": "{{count}} days ago",
       "month": "a month ago",
-      "month_plural": "{{}} months ago",
+      "month_plural": "{{count}} months ago",
       "year": "a year ago",
       "farAway": "far far away",
 

--- a/tdp_core/xlsx.py
+++ b/tdp_core/xlsx.py
@@ -110,7 +110,7 @@ def _json2xlsx():
 
   def to_value(v, coltype):
     if coltype == 'date':
-      if isinstance(v, int) or isinstance(v, int):
+      if isinstance(v, int):
         return datetime.fromtimestamp(v)
       return dateutil.parser.parse(v)
     return v


### PR DESCRIPTION
Fixes #297 

Related to Caleydo/tdp_bi_bioinfodb#1055

### Summary
* add variable `count` to language strings to display date values correctly
* remove duplicate code that has become obsolete after the migration to Python 3.7