### PR TITLE
Parse regular expression filter before storing to provenance graph

### DIFF
--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -323,7 +323,7 @@ function recordPropertyChange(source: Column | Ranking, provider: LocalDataProvi
       return;
     }
 
-    const newSerializedValue = stringifyRegExp(newValue); // serialize possible RegExp object to be properly stored as provenance graph
+    const newSerializedValue = serializeRegExp(newValue); // serialize possible RegExp object to be properly stored as provenance graph
 
     if (source instanceof Column) {
       // assert ALineUpView and update the stats
@@ -372,7 +372,7 @@ interface IRegExpFilter {
  * @param value Input string or RegExp object
  * @returns {string | IRegExpFilter} Returns the input string or a plain `IRegExpFilter` object
  */
-function stringifyRegExp(value: string | RegExp): string | IRegExpFilter {
+function serializeRegExp(value: string | RegExp): string | IRegExpFilter {
   if (!(value instanceof RegExp)) {
     return value;
   }

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -345,7 +345,7 @@ function recordPropertyChange(source: Column | Ranking, provider: LocalDataProvi
 }
 
 /**
- * Seralize RegExp objects from LineUp string columns as plain object
+ * Serialize RegExp objects from LineUp string columns as plain object
  * that can be stored in the provenance graph
  */
 interface IRegExpFilter {
@@ -384,11 +384,11 @@ function stringifyRegExp(value: string | RegExp): string | IRegExpFilter {
  * In case a string is passed to this function no deserialization is applied.
  *
  * @param filter Filter as string or plain object matching the IRegExpFilter
- * @returns {string | RegExp} Returns the input string or the restored RegExp object
+ * @returns {string | RegExp| null} Returns the input string or the restored RegExp object
  */
 function restoreRegExp(filter: string | IRegExpFilter): string | RegExp {
-  if (!(<IRegExpFilter>filter).isRegExp) {
-    return filter as string;
+  if (filter === null || !(<IRegExpFilter>filter).isRegExp) {
+    return <string | null>filter;
   }
 
   const serializedRegexParser = /^\/(.+)\/(\w+)?$/; // from https://gist.github.com/tenbits/ec7f0155b57b2d61a6cc90ef3d5f8b49


### PR DESCRIPTION
Closes Caleydo/tdp_bi_bioinfodb#1054


### Summary 
* The cause of the issue was applying` JSON.stringify()` to a RegExp object returns always  `{}`
```javascript
JSON.stringify({regexp: /^B/gm});
// result: "{\"regexp\":{}}"
```
which resulted in the provenance graph not properly storing the  filter value.

* Added a between step that:
  * transforms the regex filter to a string before storing it to the provenance graph 
  * transforms it back to a regular expression when  the replay happens.