### PR TITLE
Patch inconsistency of naming renderer getter and setter

### DIFF
--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -184,7 +184,7 @@ export function setGroupCriteria(provider: IObjectRef<any>, rid: number, columns
 export async function setColumnImpl(inputs: IObjectRef<any>[], parameter: any) {
   const p: LocalDataProvider = await resolveImmediately((await inputs[0].v).data);
   const ranking = p.getRankings()[parameter.rid];
-  let prop = parameter.prop[0].toUpperCase() + parameter.prop.slice(1);
+  const prop = parameter.prop[0].toUpperCase() + parameter.prop.slice(1);
 
   let bak = null;
   const waitForSorted = dirtyRankingWaiter(ranking);
@@ -209,6 +209,7 @@ export async function setColumnImpl(inputs: IObjectRef<any>[], parameter: any) {
         break;
     }
   }
+
   return waitForSorted({
     inverse: setColumn(inputs[0], parameter.rid, parameter.path, parameter.prop, bak)
   });

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -184,7 +184,10 @@ export function setGroupCriteria(provider: IObjectRef<any>, rid: number, columns
 export async function setColumnImpl(inputs: IObjectRef<any>[], parameter: any) {
   const p: LocalDataProvider = await resolveImmediately((await inputs[0].v).data);
   const ranking = p.getRankings()[parameter.rid];
-  const prop = parameter.prop[0].toUpperCase() + parameter.prop.slice(1);
+  let prop = parameter.prop[0].toUpperCase() + parameter.prop.slice(1);
+  if (prop === 'RendererType') {
+    prop = 'Renderer';
+  }
 
   let bak = null;
   const waitForSorted = dirtyRankingWaiter(ranking);
@@ -192,7 +195,7 @@ export async function setColumnImpl(inputs: IObjectRef<any>[], parameter: any) {
   if (parameter.path) {
     source = ranking.findByPath(parameter.path);
   }
-  ignoreNext = `${parameter.prop}Changed`;
+  // ignoreNext = `${parameter.prop}Changed`;
   if (parameter.prop === 'mapping' && source instanceof Column && isMapAbleColumn(source)) {
     bak = source.getMapping().dump();
     source.setMapping(createMappingFunction(parameter.value));
@@ -347,6 +350,7 @@ function trackColumn(provider: LocalDataProvider, lineup: IObjectRef<IViewProvid
   recordPropertyChange(col, provider, lineup, graph, 'filter');
   recordPropertyChange(col, provider, lineup, graph, 'rendererType');
   recordPropertyChange(col, provider, lineup, graph, 'groupRenderer');
+  recordPropertyChange(col, provider, lineup, graph, 'summaryRenderer');
   recordPropertyChange(col, provider, lineup, graph, 'sortMethod');
   //recordPropertyChange(col, provider, lineup, graph, 'width', 100);
 
@@ -415,7 +419,7 @@ function trackColumn(provider: LocalDataProvider, lineup: IObjectRef<IViewProvid
 
 
 function untrackColumn(col: Column) {
-  col.on(suffix('Changed.filter', 'metaData', 'filter', 'width', 'rendererType', 'groupRenderer', 'sortMethod'), null);
+  col.on(suffix('Changed.filter', 'metaData', 'filter', 'width', 'rendererType', 'groupRenderer', 'summaryRenderer', 'sortMethod'), null);
 
   if (col instanceof CompositeColumn) {
     col.on([`${CompositeColumn.EVENT_ADD_COLUMN}.track`, `${CompositeColumn.EVENT_REMOVE_COLUMN}.track`, `${CompositeColumn.EVENT_MOVE_COLUMN}.track`], null);

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -185,9 +185,6 @@ export async function setColumnImpl(inputs: IObjectRef<any>[], parameter: any) {
   const p: LocalDataProvider = await resolveImmediately((await inputs[0].v).data);
   const ranking = p.getRankings()[parameter.rid];
   let prop = parameter.prop[0].toUpperCase() + parameter.prop.slice(1);
-  if (prop === 'RendererType') {
-    prop = 'Renderer';
-  }
 
   let bak = null;
   const waitForSorted = dirtyRankingWaiter(ranking);

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -195,15 +195,23 @@ export async function setColumnImpl(inputs: IObjectRef<any>[], parameter: any) {
   if (parameter.path) {
     source = ranking.findByPath(parameter.path);
   }
-  // ignoreNext = `${parameter.prop}Changed`;
+  ignoreNext = `${parameter.prop}Changed`;
   if (parameter.prop === 'mapping' && source instanceof Column && isMapAbleColumn(source)) {
     bak = source.getMapping().dump();
     source.setMapping(createMappingFunction(parameter.value));
   } else if (source) {
-    bak = source[`get${prop}`]();
-    source[`set${prop}`].call(source, parameter.value);
+    // fixes bug that is caused by the fact that the function `getRendererType()` does not exist (only `getRenderer()`)
+    switch (parameter.prop) {
+      case 'rendererType':
+        bak = source[`getRenderer`]();
+        source[`setRenderer`].call(source, parameter.value);
+        break;
+      default:
+        bak = source[`get${prop}`]();
+        source[`set${prop}`].call(source, parameter.value);
+        break;
+    }
   }
-
   return waitForSorted({
     inverse: setColumn(inputs[0], parameter.rid, parameter.path, parameter.prop, bak)
   });


### PR DESCRIPTION
Closes Caleydo/tdp_bi_bioinfodb#1058


### Summary 
The issue was that : 
- the renderer gets tracked by providing a string from which the name of the event , the getter and the setter are created.
i.e ` recordPropertyChange(col, provider, lineup, graph, 'rendererType');`,
which produces `rendererTypeChanged, getRendererType, setRendererType`,
which of course doesn't work
- in lineup the corresponding names are:
```javascript
rendererTypeChanged
getRenderer()//instead of getRendererType()
setRenderer()//instead of setRendererType()

```
#### To discuss : 
The current implementation in tdp_core expects that the names of the event, setter and getter 
to be similar which is error prone as proved by this issue.
