### PR TITLE
Fixed disappearing of multiple push notifications

### DIFF
--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -21,7 +21,7 @@ export function pushNotification(level: 'success' | 'info' | 'warning' | 'danger
   <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
   ${msg}</div>`);
 
-  const alert = parent.lastElementChild!;
+  const alert = parent.firstElementChild!;
   // fix link color
   Array.from(alert.querySelectorAll('a')).forEach((a: HTMLElement) => a.classList.add('alert-link'));
   // try creating a slide down animation


### PR DESCRIPTION
Closes #311.

Previously, the notifications was added to the parent via `afterbegin` flag, such that new notifications where always added before older notifications. The problem is that the notification is then fetched via `parent.lastElementChild!;`, such that always the oldest notification was returned. 

Fetching the child via `parent.firstElementChild!` solves this issue. 
