### PR TITLE
Remove `overflow: hidden` to fix download drop down

### DIFF
--- a/src/styles/_view_lineup.scss
+++ b/src/styles/_view_lineup.scss
@@ -119,7 +119,6 @@ $lu_assets: "~lineupjs/src/assets";
   .lu-side-panel-wrapper {
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 
     %lu-panel-button {
       background: #fff;


### PR DESCRIPTION
Closes #320 

### Summary

The overflow hidden is not necessary anymore and cuts off the drop down of the download button.

![grafik](https://user-images.githubusercontent.com/5851088/76755954-1642a880-6785-11ea-9efa-948b47c09a1f.png)

It also works with closed side panel:

![grafik](https://user-images.githubusercontent.com/5851088/76756174-86e9c500-6785-11ea-92d8-8af29e1eb9f8.png)

Tested in Firefox 74 and Chrome 80.

