### PR TITLE
Avoid deleting the HTML node when destroying ViewWrapper instance and set visible state correctly

### DIFF
--- a/src/base/ViewWrapper.ts
+++ b/src/base/ViewWrapper.ts
@@ -120,27 +120,20 @@ export default class ViewWrapper extends EventHandler implements IViewProvider {
   }
 
   set visible(visible: boolean) {
-    (async () => { // wrap function body into an immediately invoked function expression which is async to be awaitable
-      const selection = this.inputSelections.get(DEFAULT_SELECTION_NAME);
+    const selection = this.inputSelections.get(DEFAULT_SELECTION_NAME);
 
-      let created = false;
+    if (visible) {
+      this.node.classList.remove('hidden');
+    } else {
+      this.node.classList.add('hidden');
+    }
 
-      if (visible && this.instance == null && selection && this.match(selection)) {
-        //lazy init
-        await this.createView(selection);
-        created = true;
-      }
-
-      if (visible) {
-        this.node.classList.remove('hidden');
-      } else {
-        this.node.classList.add('hidden');
-      }
-
-      if (!created) { // if the view was just created we don't need to call update again
-        this.update();
-      }
-    })();
+    if (visible && this.instance == null && selection && this.match(selection)) {
+      //lazy init
+      this.createView(selection);
+    } else {
+      this.update();  // if the view was just created we don't need to call update again
+    }
   }
 
   get visible() {

--- a/src/base/ViewWrapper.ts
+++ b/src/base/ViewWrapper.ts
@@ -206,7 +206,7 @@ export default class ViewWrapper extends EventHandler implements IViewProvider {
     } else if (this.instancePromise) {
       this.instancePromise.then(() => this.destroyInstance());
     }
-    this.node.remove();
+    this.visible = false;
   }
 
   matchesIDType(idType: IDType) {


### PR DESCRIPTION
## ViewWrapper deletes its own node from the DOM
for a description, please see the linked ticket

please test this behavior in your applications if it has any side-effects.

but as far as I can see it shouldn't. the current behavior of our detail views is that the ViewWrapper instances are created once and then the detail views are only shown and hidden via a CSS class.

but `node` of those instances should not be deleted, because the `ViewWrapper` class is only instantiated when the detail view chooser is built.

as far as I can see the `destroy` method of the `ViewWrapper` class was never called in the projects I have set up locally

### Edit:

another option would be to insert the HTML node again into the DOM, because we still have the reference to it in `this.node`

## Visible state is kept when destroying the instance

by setting the `visible` attribute of the ViewWrapper instance back to false we avoid recrating a view when we click on the centra LineUp table. see https://github.com/datavisyn/tdp_core/blob/develop/src/base/ViewWrapper.ts#L298-L300