### PR TITLE
Make LineUp v4 RegExp filter serialization backwards compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "ts-loader": "4.0.1",
     "tslib": "~1.11.0",
     "tslint": "5.9.1",
-    "ts-jest": "^25.2.1",
+    "ts-jest": "25.2.1",
     "typedoc": "~0.16.10",
     "typescript": "~3.8.2",
     "url-loader": "0.5.8",

--- a/src/lineup/internal/OverviewColumn.ts
+++ b/src/lineup/internal/OverviewColumn.ts
@@ -16,12 +16,12 @@ export default class OverviewColumn extends BooleanColumn {
 
   constructor(id: string, desc: IBooleanColumnDesc) {
     super(id, Object.assign(desc, {
-      label: i18n.t('tdp:core.lineup.OverviewColumn.overviewSelection')
+      label: i18n.t('tdp:core.lineup.OverviewColumn.overviewSelection'),
+      renderer: 'boolean',
+      groupRenderer: 'boolean',
+      summaryRenderer: 'categorical'
     }));
-    (<OverviewColumn>this).setDefaultRenderer('boolean');
-    (<OverviewColumn>this).setDefaultGroupRenderer('boolean');
-    (<OverviewColumn>this).setDefaultSummaryRenderer('categorical');
-    (<OverviewColumn>this).setWidthImpl(0); // hide
+    this.setWidthImpl(0); // hide
   }
 
   getValue(row: IDataRow) {

--- a/src/lineup/internal/OverviewColumn.ts
+++ b/src/lineup/internal/OverviewColumn.ts
@@ -18,9 +18,9 @@ export default class OverviewColumn extends BooleanColumn {
     super(id, Object.assign(desc, {
       label: i18n.t('tdp:core.lineup.OverviewColumn.overviewSelection')
     }));
-    // (<OverviewColumn>this).setDefaultRenderer('boolean');
-    // (<OverviewColumn>this).setDefaultGroupRenderer('boolean');
-    // (<OverviewColumn>this).setDefaultSummaryRenderer('categorical');
+    (<OverviewColumn>this).setDefaultRenderer('boolean');
+    (<OverviewColumn>this).setDefaultGroupRenderer('boolean');
+    (<OverviewColumn>this).setDefaultSummaryRenderer('categorical');
     (<OverviewColumn>this).setWidthImpl(0); // hide
   }
 

--- a/src/lineup/internal/OverviewColumn.ts
+++ b/src/lineup/internal/OverviewColumn.ts
@@ -18,9 +18,9 @@ export default class OverviewColumn extends BooleanColumn {
     super(id, Object.assign(desc, {
       label: i18n.t('tdp:core.lineup.OverviewColumn.overviewSelection')
     }));
-    (<OverviewColumn>this).setDefaultRenderer('boolean');
-    (<OverviewColumn>this).setDefaultGroupRenderer('boolean');
-    (<OverviewColumn>this).setDefaultSummaryRenderer('categorical');
+    // (<OverviewColumn>this).setDefaultRenderer('boolean');
+    // (<OverviewColumn>this).setDefaultGroupRenderer('boolean');
+    // (<OverviewColumn>this).setDefaultSummaryRenderer('categorical');
     (<OverviewColumn>this).setWidthImpl(0); // hide
   }
 

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -7,7 +7,7 @@ import {IObjectRef, action, meta, cat, op, ProvenanceGraph, ICmdResult} from 'ph
 import {NumberColumn, LocalDataProvider, StackColumn, ScriptColumn, OrdinalColumn, CompositeColumn, Ranking, ISortCriteria, Column, isMapAbleColumn, mappingFunctions} from 'lineupjs';
 import {resolveImmediately} from 'phovea_core/src';
 import i18n from 'phovea_core/src/i18n';
-import {isSerializedFilter, restoreLineUpFilter, serializeLineUpFilter, ILineUpStringFilter} from './cmds/filter';
+import {isSerializedFilter, restoreLineUpFilter, serializeLineUpFilter, isLineUpStringFilter} from './cmds/filter';
 
 
 // used for function calls in the context of tracking or untracking actions in the provenance graph in order to get a consistent defintion of the used strings
@@ -357,7 +357,7 @@ function recordPropertyChange(source: Column | Ranking, provider: LocalDataProvi
     }
 
     if (property === LineUpTrackAndUntrackActions.filter) {
-      newValue = isSerializedFilter(newValue) ? serializeLineUpFilter(newValue as ILineUpStringFilter) : newValue; // serialize possible RegExp object to be properly stored as provenance graph
+      newValue = isLineUpStringFilter(newValue) ? serializeLineUpFilter(newValue) : newValue; // serialize possible RegExp object to be properly stored as provenance graph
     }
 
     if (source instanceof Column) {

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -193,13 +193,6 @@ export function setGroupCriteria(provider: IObjectRef<any>, rid: number, columns
   });
 }
 
-/**
- * Check if filter has the `filter` property
- * Necessary since number columns filter has properties `min`, `max` and no filter property,
- * @param filter
- */
-const isSerializedFilter = (filter: any) => filter && filter.hasOwnProperty('filter');
-
 export async function setColumnImpl(inputs: IObjectRef<any>[], parameter: any) {
   const p: LocalDataProvider = await resolveImmediately((await inputs[0].v).data);
   const ranking = p.getRankings()[parameter.rid];
@@ -436,6 +429,16 @@ interface ISerializableLineUpFilter {
  *  Filter value
  */
 type ILineUpStringFilterValue = string[] | string | null;
+
+
+/**
+ * Check if filter has the `filter` property
+ * Necessary since number columns filter has properties `min`, `max` and no filter property,
+ * @param filter
+ */
+function isSerializedFilter(filter: any): ISerializableLineUpFilter {
+  return filter && filter.hasOwnProperty('filter');
+}
 
 /**
  * Serializes LineUp string filter, which can contain RegExp objects to an IRegexFilter object.

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -229,7 +229,9 @@ export async function setColumnImpl(inputs: IObjectRef<any>[], parameter: any) {
         break;
       default:
         bak = source[`get${prop}`]();
-        source[`set${prop}`].call(source, restoreRegExp(parameter.value)); // restore serialized regular expression before passing to LineUp
+        // restore serialized regular expression before passing to LineUp
+        const value = parameter.prop === 'filter' && serialize(parameter.value) ? restoreRegExp(parameter.value) : parameter.value;
+        source[`set${prop}`].call(source, value);
         break;
     }
   }
@@ -356,8 +358,8 @@ function recordPropertyChange(source: Column | Ranking, provider: LocalDataProvi
       return;
     }
 
-    if(property === 'filter') {
-      newValue = serializeLineUpFilter(newValue); // serialize possible RegExp object to be properly stored as provenance graph
+    if (property === 'filter') {
+      newValue = serialize(newValue) ? serializeLineUpFilter(newValue) : newValue; // serialize possible RegExp object to be properly stored as provenance graph
     }
 
     if (source instanceof Column) {

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -394,11 +394,11 @@ interface IRegExpFilter {
  * ```
  * JSON.stringify(/^123$/gm); // result: {}
  * ```
- *
+ * @internal
  * @param value Input string or RegExp object
  * @returns {string | IRegExpFilter} Returns the input string or a plain `IRegExpFilter` object
  */
-function serializeRegExp(value: string | RegExp): string | IRegExpFilter {
+export function serializeRegExp(value: string | RegExp): string | IRegExpFilter {
   if (!(value instanceof RegExp)) {
     return value;
   }
@@ -409,10 +409,11 @@ function serializeRegExp(value: string | RegExp): string | IRegExpFilter {
  * Restores a RegExp object from a given IRegExpFilter object.
  * In case a string is passed to this function no deserialization is applied.
  *
+ * @internal
  * @param filter Filter as string or plain object matching the IRegExpFilter
  * @returns {string | RegExp| null} Returns the input string or the restored RegExp object
  */
-function restoreRegExp(filter: string | IRegExpFilter): string | RegExp {
+export function restoreRegExp(filter: string | IRegExpFilter): string | RegExp {
   if (filter === null || !(<IRegExpFilter>filter).isRegExp) {
     return <string | null>filter;
   }

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -220,7 +220,7 @@ export async function setColumnImpl(inputs: IObjectRef<any>[], parameter: any) {
         bak = source[`getRenderer`]();
         source[`setRenderer`].call(source, parameter.value);
         break;
-      case 'filter':
+      case LineUpTrackAndUntrackActions.filter:
         bak = source[`get${prop}`]();
         // restore serialized regular expression before passing to LineUp
         const value = isSerializedFilter(parameter.value) ? restoreLineUpFilter(parameter.value) : parameter.value;
@@ -355,7 +355,7 @@ function recordPropertyChange(source: Column | Ranking, provider: LocalDataProvi
       return;
     }
 
-    if (property === 'filter') {
+    if (property === LineUpTrackAndUntrackActions.filter) {
       newValue = isSerializedFilter(newValue) ? serializeLineUpFilter(newValue) : newValue; // serialize possible RegExp object to be properly stored as provenance graph
     }
 

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -428,6 +428,9 @@ interface ISerializableLineUpFilter {
   filterMissing: boolean;
 }
 
+/**
+ *  Filter value
+ */
 type ILineUpStringFilterValue = string[] | string | null;
 
 /**
@@ -459,16 +462,12 @@ export function serializeLineUpFilter(filter: ILineUpStringFilter): ISerializabl
 /**
  * Restores a RegExp object from a given IRegExpFilter object.
  * In case a string is passed to this function no deserialization is applied.
- *
- * @internal
  * @param filter Filter as string or plain object matching the IRegExpFilter
  * @returns Returns the input string or the restored RegExp object
  */
 export function restoreRegExp(filter: ILineUpStringFilterValue | IRegExpFilter | ISerializableLineUpFilter, filterMissing = false): ILineUpStringFilter {
-
   const isIRegExpFilter = ((filter: IRegExpFilter | ISerializableLineUpFilter): filter is IRegExpFilter => filter.hasOwnProperty('isRegExp'));
   const isISerializableLineUpFilter = (filter: IRegExpFilter | ISerializableLineUpFilter): filter is ISerializableLineUpFilter => filter.hasOwnProperty('filterMissing');
-
   if (filter === null || typeof filter === 'string' || Array.isArray(filter)) {
     return {filter: <string | null>filter, filterMissing};
   } else if (isIRegExpFilter(filter)) {

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -198,7 +198,7 @@ export function setGroupCriteria(provider: IObjectRef<any>, rid: number, columns
  * Necessary since number columns filter has properties `min`, `max` and no filter property,
  * @param filter
  */
-const serialize = (filter: any) => filter.hasOwnProperty('filter');
+const isSerializedFilter = (filter: any) => filter.hasOwnProperty('filter');
 
 export async function setColumnImpl(inputs: IObjectRef<any>[], parameter: any) {
   const p: LocalDataProvider = await resolveImmediately((await inputs[0].v).data);
@@ -230,7 +230,7 @@ export async function setColumnImpl(inputs: IObjectRef<any>[], parameter: any) {
       default:
         bak = source[`get${prop}`]();
         // restore serialized regular expression before passing to LineUp
-        const value = parameter.prop === 'filter' && serialize(parameter.value) ? restoreRegExp(parameter.value) : parameter.value;
+        const value = parameter.prop === 'filter' && isSerializedFilter(parameter.value) ? restoreRegExp(parameter.value) : parameter.value;
         source[`set${prop}`].call(source, value);
         break;
     }
@@ -359,7 +359,7 @@ function recordPropertyChange(source: Column | Ranking, provider: LocalDataProvi
     }
 
     if (property === 'filter') {
-      newValue = serialize(newValue) ? serializeLineUpFilter(newValue) : newValue; // serialize possible RegExp object to be properly stored as provenance graph
+      newValue = isSerializedFilter(newValue) ? serializeLineUpFilter(newValue) : newValue; // serialize possible RegExp object to be properly stored as provenance graph
     }
 
     if (source instanceof Column) {

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -492,7 +492,10 @@ export function restoreLineUpFilter(filter: ILineUpStringFilterValue | IRegExpFi
 
   } else if (isISerializableLineUpFilter(filter)) {
     return restoreLineUpFilter(filter.filter, filter.filterMissing);
+
   }
+
+  throw new Error('Unknown LineUp filter format. Unable to restore the given filter.');
 }
 
 function trackColumn(provider: LocalDataProvider, lineup: IObjectRef<IViewProvider>, graph: ProvenanceGraph, col: Column) {

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -7,7 +7,7 @@ import {IObjectRef, action, meta, cat, op, ProvenanceGraph, ICmdResult} from 'ph
 import {NumberColumn, LocalDataProvider, StackColumn, ScriptColumn, OrdinalColumn, CompositeColumn, Ranking, ISortCriteria, Column, isMapAbleColumn, mappingFunctions} from 'lineupjs';
 import {resolveImmediately} from 'phovea_core/src';
 import i18n from 'phovea_core/src/i18n';
-import {isSerializedFilter, restoreLineUpFilter, serializeLineUpFilter} from './cmds/filter';
+import {isSerializedFilter, restoreLineUpFilter, serializeLineUpFilter, ILineUpStringFilter} from './cmds/filter';
 
 
 // used for function calls in the context of tracking or untracking actions in the provenance graph in order to get a consistent defintion of the used strings
@@ -357,7 +357,7 @@ function recordPropertyChange(source: Column | Ranking, provider: LocalDataProvi
     }
 
     if (property === LineUpTrackAndUntrackActions.filter) {
-      newValue = isSerializedFilter(newValue) ? serializeLineUpFilter(newValue) : newValue; // serialize possible RegExp object to be properly stored as provenance graph
+      newValue = isSerializedFilter(newValue) ? serializeLineUpFilter(newValue as ILineUpStringFilter) : newValue; // serialize possible RegExp object to be properly stored as provenance graph
     }
 
     if (source instanceof Column) {

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -389,7 +389,7 @@ interface IRegExpFilter {
   /**
    * RegExp as string
    */
-  value: string;
+  value: ILineUpStringFilterValue;
   /**
    * Flag to indicate the value should be restored as RegExp
    */
@@ -429,6 +429,7 @@ interface ISerializableLineUpFilter {
 }
 
 type ILineUpStringFilterValue = string[] | string | null;
+
 /**
  * Serializes LineUp string filter, which can contain RegExp objects to an IRegexFilter object.
  * The return value of this function can be passed to `JSON.stringify()` and stored in the provenance graph.
@@ -444,10 +445,12 @@ type ILineUpStringFilterValue = string[] | string | null;
  * @returns Returns the `ISerializableLineUpFilter` object
  */
 export function serializeLineUpFilter(filter: ILineUpStringFilter): ISerializableLineUpFilter {
+  const value = filter.filter;
+  const isRegexp = value instanceof RegExp;
   return {
     filter: {
-      value: filter.filter.toString(),
-      isRegExp: (filter.filter instanceof RegExp)
+      value: isRegexp ? value.toString() : value as ILineUpStringFilterValue,
+      isRegExp: isRegexp
     },
     filterMissing: filter.filterMissing
   };

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -227,11 +227,15 @@ export async function setColumnImpl(inputs: IObjectRef<any>[], parameter: any) {
         bak = source[`getRenderer`]();
         source[`setRenderer`].call(source, parameter.value);
         break;
-      default:
+      case 'filter':
         bak = source[`get${prop}`]();
         // restore serialized regular expression before passing to LineUp
-        const value = parameter.prop === 'filter' && isSerializedFilter(parameter.value) ? restoreRegExp(parameter.value) : parameter.value;
+        const value = isSerializedFilter(parameter.value) ? restoreRegExp(parameter.value) : parameter.value;
         source[`set${prop}`].call(source, value);
+        break;
+      default:
+        bak = source[`get${prop}`]();
+        source[`set${prop}`].call(source, parameter.value);
         break;
     }
   }

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -198,7 +198,7 @@ export function setGroupCriteria(provider: IObjectRef<any>, rid: number, columns
  * Necessary since number columns filter has properties `min`, `max` and no filter property,
  * @param filter
  */
-const isSerializedFilter = (filter: any) => filter.hasOwnProperty('filter');
+const isSerializedFilter = (filter: any) => filter && filter.hasOwnProperty('filter');
 
 export async function setColumnImpl(inputs: IObjectRef<any>[], parameter: any) {
   const p: LocalDataProvider = await resolveImmediately((await inputs[0].v).data);

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -404,7 +404,7 @@ interface ILineUpStringFilter {
   /**
    * Filter value
    */
-  filter: string[] | string | RegExp | null;
+  filter: ILineUpStringFilterValue | RegExp;
 
   /**
    * Filter for missing values
@@ -420,7 +420,7 @@ interface ISerializableLineUpFilter {
    * Filter value
    * Note that the RegExp is replaced with IRegExpFilter (compared to the `ILineUpStringFilter` interface)
    */
-  filter: string[] | string | IRegExpFilter | null;
+  filter: ILineUpStringFilterValue | IRegExpFilter;
 
   /**
    * Filter for missing values
@@ -428,6 +428,7 @@ interface ISerializableLineUpFilter {
   filterMissing: boolean;
 }
 
+type ILineUpStringFilterValue = string[] | string | null;
 /**
  * Serializes LineUp string filter, which can contain RegExp objects to an IRegexFilter object.
  * The return value of this function can be passed to `JSON.stringify()` and stored in the provenance graph.

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -193,6 +193,13 @@ export function setGroupCriteria(provider: IObjectRef<any>, rid: number, columns
   });
 }
 
+/**
+ * Check if filter has the `filter` property
+ * Necessary since number columns filter has properties `min`, `max` and no filter property,
+ * @param filter
+ */
+const serialize = (filter: any) => filter.hasOwnProperty('filter');
+
 export async function setColumnImpl(inputs: IObjectRef<any>[], parameter: any) {
   const p: LocalDataProvider = await resolveImmediately((await inputs[0].v).data);
   const ranking = p.getRankings()[parameter.rid];

--- a/src/lineup/internal/cmds/filter.ts
+++ b/src/lineup/internal/cmds/filter.ts
@@ -55,9 +55,9 @@ type ILineUpStringFilterValue = string[] | string | null;
 /**
  * This type guard checks if a given parameter has the `filter` property.
  * Necessary since number columns filter has properties `min`, `max` and no filter property,
- * @interal
- *
+ * @internal
  * @param filter Any value that could be a filter
+ * @returns Returns true if filter should be serialized/restored or false if not.
  */
 export function isSerializedFilter(filter: any): filter is ISerializableLineUpFilter | ILineUpStringFilter {
   return filter && filter.hasOwnProperty('filter');

--- a/src/lineup/internal/cmds/filter.ts
+++ b/src/lineup/internal/cmds/filter.ts
@@ -1,0 +1,126 @@
+
+/**
+ * Serialize RegExp objects from LineUp string columns as plain object
+ * that can be stored in the provenance graph
+ */
+interface IRegExpFilter {
+  /**
+   * RegExp as string
+   */
+  value: ILineUpStringFilterValue;
+  /**
+   * Flag to indicate the value should be restored as RegExp
+   */
+  isRegExp: boolean;
+}
+
+/**
+ * This interface combines the `IStringFilter` from `StringColumn`
+ * and `ICategoricalFilter` from `ICategoricalColumn`.
+ */
+interface ILineUpStringFilter {
+  /**
+   * Filter value
+   */
+  filter: ILineUpStringFilterValue | RegExp;
+
+  /**
+   * Filter for missing values
+   */
+  filterMissing: boolean;
+}
+
+/**
+ * Similar to the `ILineUpStringFilter`, but the RegExp is replaced with `IRegExpFilter`
+ */
+interface ISerializableLineUpFilter {
+  /**
+   * Filter value
+   * Note that the RegExp is replaced with IRegExpFilter (compared to the `ILineUpStringFilter` interface)
+   */
+  filter: ILineUpStringFilterValue | IRegExpFilter;
+
+  /**
+   * Filter for missing values
+   */
+  filterMissing: boolean;
+}
+
+/**
+ *  Filter value
+ */
+type ILineUpStringFilterValue = string[] | string | null;
+
+
+/**
+ * This type guard checks if a given parameter has the `filter` property.
+ * Necessary since number columns filter has properties `min`, `max` and no filter property,
+ * @interal
+ *
+ * @param filter Any value that could be a filter
+ */
+export function isSerializedFilter(filter: any): ISerializableLineUpFilter {
+  return filter && filter.hasOwnProperty('filter');
+}
+
+/**
+ * Serializes LineUp string filter, which can contain RegExp objects to an IRegexFilter object.
+ * The return value of this function can be passed to `JSON.stringify()` and stored in the provenance graph.
+ *
+ * Background information:
+ * The serialization step is necessary, because RegExp objects are converted into an empty object `{}` on `JSON.stringify`.
+ * ```
+ * JSON.stringify(/^123$/gm); // result: {}
+ * ```
+ *
+ * @internal
+ *
+ * @param filter LineUp filter object
+ * @returns Returns the `ISerializableLineUpFilter` object
+ */
+export function serializeLineUpFilter(filter: ILineUpStringFilter): ISerializableLineUpFilter {
+  const value = filter.filter;
+  const isRegexp = value instanceof RegExp;
+  return {
+    filter: {
+      value: isRegexp ? value.toString() : value as ILineUpStringFilterValue,
+      isRegExp: isRegexp
+    },
+    filterMissing: filter.filterMissing
+  };
+}
+
+/**
+ * Restores a RegExp object from a given IRegExpFilter object.
+ * In case a string is passed to this function no deserialization is applied.
+ *
+ * @interal
+ * @param filter Filter as string or plain object matching the IRegExpFilter
+ * @param filterMissing The flag indicates if missing values should be filtered (default = `false`)
+ * @returns Returns the input string or the restored RegExp object
+ */
+export function restoreLineUpFilter(filter: ILineUpStringFilterValue | IRegExpFilter | ISerializableLineUpFilter, filterMissing = false): ILineUpStringFilter {
+  const isSimpleFilter = (filter: ILineUpStringFilterValue | IRegExpFilter | ISerializableLineUpFilter): filter is ILineUpStringFilterValue => filter === null || typeof filter === 'string' || Array.isArray(filter);
+  const isIRegExpFilter = ((filter: IRegExpFilter | ISerializableLineUpFilter): filter is IRegExpFilter => filter.hasOwnProperty('isRegExp'));
+  const isISerializableLineUpFilter = (filter: IRegExpFilter | ISerializableLineUpFilter): filter is ISerializableLineUpFilter => filter.hasOwnProperty('filterMissing');
+
+  if (isSimpleFilter(filter)) {
+    return {filter, filterMissing};
+
+  } else if (isIRegExpFilter(filter)) {
+    if (filter.isRegExp) {
+      const serializedRegexParser = /^\/(.+)\/(\w+)?$/; // from https://gist.github.com/tenbits/ec7f0155b57b2d61a6cc90ef3d5f8b49
+      const matches = serializedRegexParser.exec(filter.value as string);
+      const [_full, regexString, regexFlags] = matches;
+      return {filter: new RegExp(regexString, regexFlags), filterMissing};
+    }
+
+    return restoreLineUpFilter(filter.value, filterMissing);
+
+  } else if (isISerializableLineUpFilter(filter)) {
+    return restoreLineUpFilter(filter.filter, filter.filterMissing);
+
+  }
+
+  throw new Error('Unknown LineUp filter format. Unable to restore the given filter.');
+}

--- a/src/lineup/internal/cmds/filter.ts
+++ b/src/lineup/internal/cmds/filter.ts
@@ -18,7 +18,7 @@ interface IRegExpFilter {
  * This interface combines the `IStringFilter` from `StringColumn`
  * and `ICategoricalFilter` from `ICategoricalColumn`.
  */
-interface ILineUpStringFilter {
+export interface ILineUpStringFilter {
   /**
    * Filter value
    */
@@ -59,7 +59,7 @@ type ILineUpStringFilterValue = string[] | string | null;
  *
  * @param filter Any value that could be a filter
  */
-export function isSerializedFilter(filter: any): ISerializableLineUpFilter {
+export function isSerializedFilter(filter: any): filter is ISerializableLineUpFilter | ILineUpStringFilter {
   return filter && filter.hasOwnProperty('filter');
 }
 
@@ -99,10 +99,10 @@ export function serializeLineUpFilter(filter: ILineUpStringFilter): ISerializabl
  * @param filterMissing The flag indicates if missing values should be filtered (default = `false`)
  * @returns Returns the input string or the restored RegExp object
  */
-export function restoreLineUpFilter(filter: ILineUpStringFilterValue | IRegExpFilter | ISerializableLineUpFilter, filterMissing = false): ILineUpStringFilter {
-  const isSimpleFilter = (filter: ILineUpStringFilterValue | IRegExpFilter | ISerializableLineUpFilter): filter is ILineUpStringFilterValue => filter === null || typeof filter === 'string' || Array.isArray(filter);
-  const isIRegExpFilter = ((filter: IRegExpFilter | ISerializableLineUpFilter): filter is IRegExpFilter => filter.hasOwnProperty('isRegExp'));
-  const isISerializableLineUpFilter = (filter: IRegExpFilter | ISerializableLineUpFilter): filter is ISerializableLineUpFilter => filter.hasOwnProperty('filterMissing');
+export function restoreLineUpFilter(filter: ILineUpStringFilterValue | IRegExpFilter | ISerializableLineUpFilter | ILineUpStringFilter, filterMissing = false): ILineUpStringFilter {
+  const isSimpleFilter = (filter: ILineUpStringFilterValue | IRegExpFilter | ISerializableLineUpFilter | ILineUpStringFilter): filter is ILineUpStringFilterValue => filter === null || typeof filter === 'string' || Array.isArray(filter) || filter instanceof RegExp;
+  const isIRegExpFilter = ((filter: IRegExpFilter | ISerializableLineUpFilter | ILineUpStringFilter): filter is IRegExpFilter => filter.hasOwnProperty('isRegExp'));
+  const isISerializableLineUpFilter = (filter: IRegExpFilter | ISerializableLineUpFilter | ILineUpStringFilter): filter is ISerializableLineUpFilter => filter.hasOwnProperty('filterMissing');
 
   if (isSimpleFilter(filter)) {
     return {filter, filterMissing};

--- a/tests/lineup/internal/cmds.test.ts
+++ b/tests/lineup/internal/cmds.test.ts
@@ -30,16 +30,59 @@ describe('Serialize LineUp v4 filter for provenance graph', () => {
     expect(serializeLineUpFilter(lineUpFilter)).not.toMatchObject({filter: {value: '/12345/gm', isRegExp: true}, filterMissing: false});
     expect(serializeLineUpFilter(lineUpFilter)).not.toMatchObject({filter: {value: '/abc/gm', isRegExp: false}, filterMissing: false});
   });
+
+  it('filter as array', () => {
+    const lineUpFilter = {filter: ['chromosome', 'gender'], filterMissing: false};
+    expect(serializeLineUpFilter(lineUpFilter)).toMatchObject({filter: {value: ['chromosome', 'gender'], isRegExp: false}, filterMissing: false});
+  });
+
+  it('filter as null', () => {
+    const lineUpFilter = {filter: null, filterMissing: false};
+    expect(serializeLineUpFilter(lineUpFilter)).toMatchObject({filter: {value: null, isRegExp: false}, filterMissing: false});
+  });
+
+  it('filter as null and use regular expression true', () => {
+    const lineUpFilter = {filter: /null/, filterMissing: false};
+    expect(serializeLineUpFilter(lineUpFilter)).toMatchObject({filter: {value: /null/, isRegExp: true}, filterMissing: false});
+  });
 });
+
 
 describe('Restore LineUp filter from provenance graph', () => {
   it('filter as string', () => {
-    expect(restoreRegExp('abc')).toBe('abc');
-    expect(typeof restoreRegExp('abc')).toBe('string');
+    expect(restoreRegExp('abc')).toMatchObject({filter: 'abc', filterMissing: false});
+    expect(restoreRegExp('abc').hasOwnProperty('filterMissing')).toBeTruthy();
   });
 
-  it('filter as IRegExpFilter', () => {
-    expect(restoreRegExp({value: '/abc/gm', isRegExp: true})).toMatchObject(/abc/gm);
+  it('filter as null', () => {
+    expect(restoreRegExp(null)).toMatchObject({filter: null, filterMissing: false});
+  });
+
+  it('filter as IRegExpFilter with `value:abc`, `isRegexp:false`', () => {
+    expect(restoreRegExp({value: 'abc', isRegExp: false})).toMatchObject({filter: 'abc', filterMissing: false});
+  });
+
+  it('filter as IRegExpFilter with `value:null`, `isRegexp:false`', () => {
+    expect(restoreRegExp({value: null, isRegExp: false})).toMatchObject({filter: null, filterMissing: false});
+  });
+
+  it('filter as IRegExpFilter with `value:/^abc/gm`, `isRegexp:true`', () => {
+    expect(restoreRegExp({value: '/^abc/gm', isRegExp: true})).toMatchObject({filter: /^abc/gm, filterMissing: false});
+  });
+
+  it('filter as ISerializableLineUpFilter', () => {
+    const fromGraphFilter = {filter: {value: '/abc$/gm', isRegExp: true}, filterMissing: false};
+    expect(restoreRegExp(fromGraphFilter)).toMatchObject({filter: /abc$/gm, filterMissing: false});
+  });
+
+  it('filter as ISerializableLineUpFilter with property `filterMissing: true`', () => {
+    const fromGraphFilter = {filter: {value: '/abc$/gm', isRegExp: true}, filterMissing: true};
+    expect(restoreRegExp(fromGraphFilter)).toMatchObject({filter: /abc$/gm, filterMissing: true});
+  });
+
+  it('filter as ISerializableLineUpFilter with property `value: null`', () => {
+    const fromGraphFilter = {filter: {value: null, isRegExp: false}, filterMissing: true};
+    expect(restoreRegExp(fromGraphFilter)).toMatchObject({filter: null, filterMissing: true});
   });
 });
 

--- a/tests/lineup/internal/cmds.test.ts
+++ b/tests/lineup/internal/cmds.test.ts
@@ -1,5 +1,5 @@
 /// <reference types="jest" />
-import {serializeLineUpFilter, restoreRegExp} from '../../../src/lineup/internal/cmds';
+import {serializeLineUpFilter, restoreLineUpFilter} from '../../../src/lineup/internal/cmds';
 
 // The following tests worked with LineUp v3.
 // With LineUp v4 the filter object changed
@@ -36,53 +36,49 @@ describe('Serialize LineUp v4 filter for provenance graph', () => {
     expect(serializeLineUpFilter(lineUpFilter)).toMatchObject({filter: {value: ['chromosome', 'gender'], isRegExp: false}, filterMissing: false});
   });
 
-  it('filter as null', () => {
-    const lineUpFilter = {filter: null, filterMissing: false};
-    expect(serializeLineUpFilter(lineUpFilter)).toMatchObject({filter: {value: null, isRegExp: false}, filterMissing: false});
-  });
-
   it('filter as null and use regular expression true', () => {
-    const lineUpFilter = {filter: /null/, filterMissing: false};
-    expect(serializeLineUpFilter(lineUpFilter)).toMatchObject({filter: {value: /null/, isRegExp: true}, filterMissing: false});
+    const lineUpFilter = {filter: null, filterMissing: true};
+    expect(serializeLineUpFilter(lineUpFilter)).toMatchObject({filter: {value: null, isRegExp: false}, filterMissing: true});
   });
 });
 
 
 describe('Restore LineUp filter from provenance graph', () => {
   it('filter as string', () => {
-    expect(restoreRegExp('abc')).toMatchObject({filter: 'abc', filterMissing: false});
-    expect(restoreRegExp('abc').hasOwnProperty('filterMissing')).toBeTruthy();
+    expect(restoreLineUpFilter('abc')).toMatchObject({filter: 'abc', filterMissing: false});
+    expect(restoreLineUpFilter('abc').hasOwnProperty('filterMissing')).toBeTruthy();
   });
 
-  it('filter as null', () => {
-    expect(restoreRegExp(null)).toMatchObject({filter: null, filterMissing: false});
+  it('filter as null and `filterMissing: true`', () => {
+    const fromGraphFilter = {filter: {value: null, isRegExp: false}, filterMissing: true};
+    expect(restoreLineUpFilter(fromGraphFilter)).toMatchObject({filter: null, filterMissing: true});
   });
 
   it('filter as IRegExpFilter with `value:abc`, `isRegexp:false`', () => {
-    expect(restoreRegExp({value: 'abc', isRegExp: false})).toMatchObject({filter: 'abc', filterMissing: false});
+    expect(restoreLineUpFilter({value: 'abc', isRegExp: false})).toMatchObject({filter: 'abc', filterMissing: false});
   });
 
   it('filter as IRegExpFilter with `value:null`, `isRegexp:false`', () => {
-    expect(restoreRegExp({value: null, isRegExp: false})).toMatchObject({filter: null, filterMissing: false});
+    expect(restoreLineUpFilter({value: null, isRegExp: false})).toMatchObject({filter: null, filterMissing: false});
   });
 
   it('filter as IRegExpFilter with `value:/^abc/gm`, `isRegexp:true`', () => {
-    expect(restoreRegExp({value: '/^abc/gm', isRegExp: true})).toMatchObject({filter: /^abc/gm, filterMissing: false});
+    expect(restoreLineUpFilter({value: '/^abc/gm', isRegExp: true})).toMatchObject({filter: /^abc/gm, filterMissing: false});
   });
 
   it('filter as ISerializableLineUpFilter', () => {
     const fromGraphFilter = {filter: {value: '/abc$/gm', isRegExp: true}, filterMissing: false};
-    expect(restoreRegExp(fromGraphFilter)).toMatchObject({filter: /abc$/gm, filterMissing: false});
+    expect(restoreLineUpFilter(fromGraphFilter)).toMatchObject({filter: /abc$/gm, filterMissing: false});
   });
 
   it('filter as ISerializableLineUpFilter with property `filterMissing: true`', () => {
     const fromGraphFilter = {filter: {value: '/abc$/gm', isRegExp: true}, filterMissing: true};
-    expect(restoreRegExp(fromGraphFilter)).toMatchObject({filter: /abc$/gm, filterMissing: true});
+    expect(restoreLineUpFilter(fromGraphFilter)).toMatchObject({filter: /abc$/gm, filterMissing: true});
   });
 
   it('filter as ISerializableLineUpFilter with property `value: null`', () => {
     const fromGraphFilter = {filter: {value: null, isRegExp: false}, filterMissing: true};
-    expect(restoreRegExp(fromGraphFilter)).toMatchObject({filter: null, filterMissing: true});
+    expect(restoreLineUpFilter(fromGraphFilter)).toMatchObject({filter: null, filterMissing: true});
   });
 });
 

--- a/tests/lineup/internal/cmds.test.ts
+++ b/tests/lineup/internal/cmds.test.ts
@@ -1,0 +1,29 @@
+/// <reference types="jest" />
+import {serializeRegExp, restoreRegExp} from '../../../src/lineup/internal/cmds';
+
+describe('Serialize LineUp filter for provenance graph', () => {
+  it('filter as string', () => {
+    expect(serializeRegExp('abc')).toBe('abc');
+    expect(typeof serializeRegExp('abc')).toBe('string');
+  });
+
+  // The following tests worked with LineUp v3.
+  // With LineUp v4 the filter object changed
+  it('filter as RegExp', () => {
+    expect(serializeRegExp(/abc/gm)).toMatchObject({value: '/abc/gm', isRegExp: true});
+    expect(serializeRegExp(/abc/gm)).not.toMatchObject({value: '/12345/gm', isRegExp: true});
+    expect(serializeRegExp(/abc/gm)).not.toMatchObject({value: '/abc/gm', isRegExp: false});
+  });
+});
+
+describe('Restore LineUp filter from provenance graph', () => {
+  it('filter as string', () => {
+    expect(restoreRegExp('abc')).toBe('abc');
+    expect(typeof restoreRegExp('abc')).toBe('string');
+  });
+
+  it('filter as IRegExpFilter', () => {
+    expect(restoreRegExp({value: '/abc/gm', isRegExp: true})).toMatchObject(/abc/gm);
+  });
+});
+

--- a/tests/lineup/internal/cmds.test.ts
+++ b/tests/lineup/internal/cmds.test.ts
@@ -1,18 +1,34 @@
 /// <reference types="jest" />
-import {serializeRegExp, restoreRegExp} from '../../../src/lineup/internal/cmds';
+import {serializeLineUpFilter, restoreRegExp} from '../../../src/lineup/internal/cmds';
 
-describe('Serialize LineUp filter for provenance graph', () => {
+// The following tests worked with LineUp v3.
+// With LineUp v4 the filter object changed
+// describe('Serialize LineUp v3 filter for provenance graph', () => {
+//   it('filter as string', () => {
+//     expect(serializeRegExp('abc')).toBe('abc');
+//     expect(typeof serializeRegExp('abc')).toBe('string');
+//   });
+
+//   it('filter as RegExp', () => {
+//     expect(serializeRegExp(/abc/gm)).toMatchObject({value: '/abc/gm', isRegExp: true});
+//     expect(serializeRegExp(/abc/gm)).not.toMatchObject({value: '/12345/gm', isRegExp: true});
+//     expect(serializeRegExp(/abc/gm)).not.toMatchObject({value: '/abc/gm', isRegExp: false});
+//   });
+// });
+
+describe('Serialize LineUp v4 filter for provenance graph', () => {
   it('filter as string', () => {
-    expect(serializeRegExp('abc')).toBe('abc');
-    expect(typeof serializeRegExp('abc')).toBe('string');
+    const lineUpFilter = {filter: 'abc', filterMissing: false};
+
+    expect(serializeLineUpFilter(lineUpFilter)).toMatchObject({filter: {value: 'abc', isRegExp: false}, filterMissing: false});
   });
 
-  // The following tests worked with LineUp v3.
-  // With LineUp v4 the filter object changed
   it('filter as RegExp', () => {
-    expect(serializeRegExp(/abc/gm)).toMatchObject({value: '/abc/gm', isRegExp: true});
-    expect(serializeRegExp(/abc/gm)).not.toMatchObject({value: '/12345/gm', isRegExp: true});
-    expect(serializeRegExp(/abc/gm)).not.toMatchObject({value: '/abc/gm', isRegExp: false});
+    const lineUpFilter = {filter: /abc/gm, filterMissing: false};
+
+    expect(serializeLineUpFilter(lineUpFilter)).toMatchObject({filter: {value: '/abc/gm', isRegExp: true}, filterMissing: false});
+    expect(serializeLineUpFilter(lineUpFilter)).not.toMatchObject({filter: {value: '/12345/gm', isRegExp: true}, filterMissing: false});
+    expect(serializeLineUpFilter(lineUpFilter)).not.toMatchObject({filter: {value: '/abc/gm', isRegExp: false}, filterMissing: false});
   });
 });
 

--- a/tests/lineup/internal/cmds.test.ts
+++ b/tests/lineup/internal/cmds.test.ts
@@ -54,15 +54,15 @@ describe('Restore LineUp filter from provenance graph', () => {
     expect(restoreLineUpFilter(fromGraphFilter)).toMatchObject({filter: null, filterMissing: true});
   });
 
-  it('filter as IRegExpFilter with `value:abc`, `isRegexp:false`', () => {
+  it('filter as IRegExpFilter with `value: abc`, `isRegexp: false`', () => {
     expect(restoreLineUpFilter({value: 'abc', isRegExp: false})).toMatchObject({filter: 'abc', filterMissing: false});
   });
 
-  it('filter as IRegExpFilter with `value:null`, `isRegexp:false`', () => {
+  it('filter as IRegExpFilter with `value: null`, `isRegexp: false`', () => {
     expect(restoreLineUpFilter({value: null, isRegExp: false})).toMatchObject({filter: null, filterMissing: false});
   });
 
-  it('filter as IRegExpFilter with `value:/^abc/gm`, `isRegexp:true`', () => {
+  it('filter as IRegExpFilter with `value: /^abc/gm`, `isRegexp: true`', () => {
     expect(restoreLineUpFilter({value: '/^abc/gm', isRegExp: true})).toMatchObject({filter: /^abc/gm, filterMissing: false});
   });
 
@@ -79,6 +79,12 @@ describe('Restore LineUp filter from provenance graph', () => {
   it('filter as ISerializableLineUpFilter with property `value: null`', () => {
     const fromGraphFilter = {filter: {value: null, isRegExp: false}, filterMissing: true};
     expect(restoreLineUpFilter(fromGraphFilter)).toMatchObject({filter: null, filterMissing: true});
+  });
+
+  it('unknown filter format throws error', () => {
+    expect(() => {
+      restoreLineUpFilter(<any>123456789); // typecast to pass unknown format
+    }).toThrowError(new Error('Unknown LineUp filter format. Unable to restore the given filter.'));
   });
 });
 

--- a/tests/lineup/internal/cmds/filter.test.ts
+++ b/tests/lineup/internal/cmds/filter.test.ts
@@ -1,5 +1,5 @@
 /// <reference types="jest" />
-import {serializeLineUpFilter, restoreLineUpFilter, ILineUpStringFilter} from '../../../../src/lineup/internal/cmds/filter';
+import {serializeLineUpFilter, restoreLineUpFilter, isSerializedFilter, isLineUpStringFilter, restoreRegExp} from '../../../../src/lineup/internal/cmds/filter';
 
 // The following tests worked with LineUp v3.
 // With LineUp v4 the filter object changed
@@ -15,6 +15,55 @@ import {serializeLineUpFilter, restoreLineUpFilter, ILineUpStringFilter} from '.
 //     expect(serializeRegExp(/abc/gm)).not.toMatchObject({value: '/abc/gm', isRegExp: false});
 //   });
 // });
+
+describe('Type guard isLineUpStringFilter', () => {
+  it('isLineUpStringFilter with string', () => {
+    expect(isLineUpStringFilter({filter: 'abc', filterMissing: false})).toBe(true);
+  });
+
+  it('isLineUpStringFilter with string[]', () => {
+    expect(isLineUpStringFilter({filter: ['abc', 'def'], filterMissing: false})).toBe(true);
+  });
+
+  it('isLineUpStringFilter with null', () => {
+    expect(isLineUpStringFilter({filter: null, filterMissing: false})).toBe(true);
+  });
+
+  it('isLineUpStringFilter with RegExp', () => {
+    expect(isLineUpStringFilter({filter: /abc/gm, filterMissing: false})).toBe(true);
+  });
+});
+
+describe('Type guard isSerializedFilter', () => {
+  it('isSerializedFilter with string', () => {
+    expect(isSerializedFilter({filter: {value: 'abc', isRegExp: false}, filterMissing: false})).toBe(true);
+  });
+
+  it('isSerializedFilter with string[]', () => {
+    expect(isSerializedFilter({filter: {value: ['abc', 'def'], isRegExp: false}, filterMissing: false})).toBe(true);
+  });
+
+  it('isSerializedFilter with null', () => {
+    expect(isSerializedFilter({filter: {value: null, isRegExp: false}, filterMissing: false})).toBe(true);
+  });
+
+  it('isSerializedFilter with RegExp', () => {
+    expect(isSerializedFilter({filter: {value: '/abc/gm', isRegExp: true}, filterMissing: false})).toBe(true);
+  });
+});
+
+describe('Restore RegExp from string', () => {
+  it('valid RegExp string', () => {
+    expect(restoreRegExp('/abc/gm').toString()).toBe('/abc/gm');
+    expect(restoreRegExp('/def/gm').toString()).not.toBe('/abc/gm');
+  });
+
+  it('invalid RegExp string', () => {
+    expect(() => {
+      restoreRegExp('invalid regexp string').toString();
+    }).toThrow(new Error('Unable to parse regular expression from string. The string does not seem to be a valid RegExp.'));
+  });
+});
 
 describe('Serialize LineUp v4 filter for provenance graph', () => {
   it('filter as string', () => {

--- a/tests/lineup/internal/cmds/filter.test.ts
+++ b/tests/lineup/internal/cmds/filter.test.ts
@@ -1,5 +1,5 @@
 /// <reference types="jest" />
-import {serializeLineUpFilter, restoreLineUpFilter} from '../../../src/lineup/internal/cmds';
+import {serializeLineUpFilter, restoreLineUpFilter} from '../../../../src/lineup/internal/cmds/filter';
 
 // The following tests worked with LineUp v3.
 // With LineUp v4 the filter object changed

--- a/tests/lineup/internal/cmds/filter.test.ts
+++ b/tests/lineup/internal/cmds/filter.test.ts
@@ -1,5 +1,5 @@
 /// <reference types="jest" />
-import {serializeLineUpFilter, restoreLineUpFilter} from '../../../../src/lineup/internal/cmds/filter';
+import {serializeLineUpFilter, restoreLineUpFilter, ILineUpStringFilter} from '../../../../src/lineup/internal/cmds/filter';
 
 // The following tests worked with LineUp v3.
 // With LineUp v4 the filter object changed
@@ -83,7 +83,7 @@ describe('Restore LineUp filter from provenance graph', () => {
 
   it('filter as RegExp `filterMissing: false', () => {
     const fromGraphFilter = {filter: /abc/, filterMissing: false};
-    expect(restoreLineUpFilter(<any>fromGraphFilter)).toMatchObject({filter: /abc/, filterMissing: false});
+    expect(restoreLineUpFilter(fromGraphFilter)).toMatchObject({filter: /abc/, filterMissing: false});
   });
 
   it('unknown filter format throws error', () => {

--- a/tests/lineup/internal/cmds/filter.test.ts
+++ b/tests/lineup/internal/cmds/filter.test.ts
@@ -81,6 +81,11 @@ describe('Restore LineUp filter from provenance graph', () => {
     expect(restoreLineUpFilter(fromGraphFilter)).toMatchObject({filter: null, filterMissing: true});
   });
 
+  it('filter as RegExp `filterMissing: false', () => {
+    const fromGraphFilter = {filter: /abc/, filterMissing: false};
+    expect(restoreLineUpFilter(<any>fromGraphFilter)).toMatchObject({filter: /abc/, filterMissing: false});
+  });
+
   it('unknown filter format throws error', () => {
     expect(() => {
       restoreLineUpFilter(<any>123456789); // typecast to pass unknown format

--- a/tests/lineup/internal/cmds/filter.test.ts
+++ b/tests/lineup/internal/cmds/filter.test.ts
@@ -81,11 +81,6 @@ describe('Restore LineUp filter from provenance graph', () => {
     expect(restoreLineUpFilter(fromGraphFilter)).toMatchObject({filter: null, filterMissing: true});
   });
 
-  it('filter as RegExp `filterMissing: false', () => {
-    const fromGraphFilter = {filter: /abc/, filterMissing: false};
-    expect(restoreLineUpFilter(fromGraphFilter)).toMatchObject({filter: /abc/, filterMissing: false});
-  });
-
   it('unknown filter format throws error', () => {
     expect(() => {
       restoreLineUpFilter(<any>123456789); // typecast to pass unknown format


### PR DESCRIPTION
Close datavisyn/tdp_core#331

## Summary 

* Extended tests for `serializeLineUpFilter()` and `restoreRegExp()` functions.
* Refactored the functions to be backwards compatible.