### PR TITLE
Ignore live preview events

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "phovea_clue": "github:phovea/phovea_clue#develop",
     "select2": "~4.0.13",
     "select2-bootstrap-theme": "0.1.0-beta.9",
-    "lodash": "^4.17.15"
+    "lodash": "~4.17.15"
   },
   "main": "build/tdp_core.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "lineupjs": "github:lineupjs/lineupjs#lineup-v4",
     "phovea_clue": "github:phovea/phovea_clue#develop",
     "select2": "~4.0.13",
-    "select2-bootstrap-theme": "0.1.0-beta.9"
+    "select2-bootstrap-theme": "0.1.0-beta.9",
+    "lodash": "^4.17.15"
   },
   "main": "build/tdp_core.js",
   "devDependencies": {

--- a/src/lineup/ARankingView.ts
+++ b/src/lineup/ARankingView.ts
@@ -293,6 +293,11 @@ export abstract class ARankingView extends AView {
       violationChanged: (_: IRule, violation: string) => this.panel.setViolation(violation)
     }));
 
+    // LineUp creates an element with class `lu-backdrop` that fades out all content when a dialog is opened.
+    // Append `lu-backdrop` one level higher so fading effect can be applied also to the sidePanel when a dialog is opened.
+    const luBackdrop = this.node.querySelector('.lu-backdrop');
+    this.node.appendChild(luBackdrop);
+
     this.panel = new LineUpPanelActions(this.provider, this.taggle.ctx, this.options, this.node.ownerDocument);
     this.panel.on(LineUpPanelActions.EVENT_SAVE_NAMED_SET, (_event, order: number[], name: string, description: string, sec: Partial<ISecureItem>) => {
       this.saveNamedSet(order, name, description, sec);

--- a/src/lineup/ARankingView.ts
+++ b/src/lineup/ARankingView.ts
@@ -608,7 +608,7 @@ export abstract class ARankingView extends AView {
       this.builtLineUp(this.provider);
 
       //record after the initial one
-      clueify(this.context.ref, this.context.graph);
+      clueify(this.taggle, this.context.ref, this.context.graph);
       this.setBusy(false);
     }).catch(showErrorModalDialog)
       .catch((error) => {

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -371,7 +371,7 @@ function rankingId(provider: LocalDataProvider, ranking: Ranking): number {
  * @param delayed Number of milliseconds to delay the tracking call (default is -1 = immediately)
  */
 function recordPropertyChange(source: Column | Ranking, provider: LocalDataProvider, objectRef: IObjectRef<IViewProvider>, graph: ProvenanceGraph, property: string, delayed = -1): void {
-  const func = (old: any, newValue: any) => {
+  const func = (oldValue: any, newValue: any) => {
     if (ignore(`${property}Changed`, objectRef)) {
       return;
     }
@@ -385,15 +385,17 @@ function recordPropertyChange(source: Column | Ranking, provider: LocalDataProvi
       const rid = rankingId(provider, source.findMyRanker());
       const path = source.fqpath;
       graph.pushWithResult(setColumn(objectRef, rid, path, property, newSerializedValue), {
-        inverse: setColumn(objectRef, rid, path, property, old)
+        inverse: setColumn(objectRef, rid, path, property, oldValue)
       });
+
     } else if (source instanceof Ranking) {
       const rid = rankingId(provider, source);
       graph.pushWithResult(setColumn(objectRef, rid, null, property, newSerializedValue), {
-        inverse: setColumn(objectRef, rid, null, property, old)
+        inverse: setColumn(objectRef, rid, null, property, oldValue)
       });
     }
   };
+
   source.on(`${property}Changed.track`, delayed > 0 ? delayedCall(func, delayed) : func);
 }
 

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -613,9 +613,13 @@ function trackRanking(lineup: EngineRenderer | TaggleRenderer, provider: LocalDa
     isDialogOpen = false;
   });
 
-// Close all dialogs when clicking on an action in the provenance graph tree in order
-// to execute the action instead of buffering it as is the case when a dialog is open
+  // Close all dialogs before executing any provenance action or run the provenance chain
+  // (otherwise actions would be buffered while a dialog is open and result in a wrong application state)
   graph.on('run_chain', () => {
+    lineup.ctx.dialogManager.removeAll();
+  });
+
+  graph.on('execute', () => {
     lineup.ctx.dialogManager.removeAll();
   });
 

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -613,6 +613,11 @@ function trackRanking(lineup: EngineRenderer | TaggleRenderer, provider: LocalDa
     isDialogOpen = false;
   });
 
+// Close all dialogs when clicking on an action in the provenance graph tree in order
+// to execute the action instead of buffering it as is the case when a dialog is open
+  graph.on('run_chain', () => {
+    lineup.ctx.dialogManager.removeAll();
+  });
 
   ranking.on(`${Ranking.EVENT_SORT_CRITERIA_CHANGED}.track`, (old: ISortCriteria[], newValue: ISortCriteria[]) => {
     // wrap the execution in a function to buffer it if a dialog is open

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -124,8 +124,15 @@ export function addRanking(provider: IObjectRef<any>, index: number, dump?: any)
   });
 }
 
-function toSortObject(v) {
-  return {asc: v.asc, col: v.col ? v.col.fqpath : null};
+/**
+ * Create an object structure from the LineUp sort event listener that can stored in a provenance graph
+ * @param v Object from LineUp sort event listener
+ */
+function toSortObject(v: any) {
+  return {
+    asc: v.asc,
+    col: v.col ? v.col.fqpath : null
+  };
 }
 
 export async function setRankingSortCriteriaImpl(inputs: IObjectRef<any>[], parameter: any) {
@@ -608,12 +615,13 @@ function trackRanking(lineup: EngineRenderer | TaggleRenderer, provider: LocalDa
 
 
   ranking.on(`${Ranking.EVENT_SORT_CRITERIA_CHANGED}.track`, (old: ISortCriteria[], newValue: ISortCriteria[]) => {
-
+    // wrap the execution in a function to buffer it if a dialog is open
     const execute = (initialState: ISortCriteria[] = old) => {
       if (ignore(Ranking.EVENT_SORT_CRITERIA_CHANGED, objectRef)) {
         return;
       }
 
+      // cancel the execution if nothing has changed
       if (isEqual(initialState.map(toSortObject), newValue.map(toSortObject))) {
         return;
       }
@@ -633,11 +641,13 @@ function trackRanking(lineup: EngineRenderer | TaggleRenderer, provider: LocalDa
   });
 
   ranking.on(`${Ranking.EVENT_GROUP_SORT_CRITERIA_CHANGED}.track`, (old: ISortCriteria[], newValue: ISortCriteria[]) => {
+    // wrap the execution in a function to buffer it if a dialog is open
     const execute = (initialState: ISortCriteria[] = old) => {
       if (ignore(Ranking.EVENT_GROUP_SORT_CRITERIA_CHANGED, objectRef)) {
         return;
       }
 
+      // cancel the execution if nothing has changed
       if (isEqual(initialState.map(toSortObject), newValue.map(toSortObject))) {
         return;
       }
@@ -657,11 +667,13 @@ function trackRanking(lineup: EngineRenderer | TaggleRenderer, provider: LocalDa
   });
 
   ranking.on(`${Ranking.EVENT_GROUP_CRITERIA_CHANGED}.track`, (old: Column[], newValue: Column[]) => {
+    // wrap the execution in a function to buffer it if a dialog is open
     const execute = (initialState: Column[] = old) => {
       if (ignore(Ranking.EVENT_GROUP_CRITERIA_CHANGED, objectRef)) {
         return;
       }
 
+      // cancel the execution if nothing has changed
       if (isEqual(initialState, newValue)) {
         return;
       }

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -4,7 +4,7 @@
 
 
 import {IObjectRef, action, meta, cat, op, ProvenanceGraph, ICmdResult} from 'phovea_core/src/provenance';
-import {NumberColumn, LocalDataProvider, StackColumn, ScriptColumn, OrdinalColumn, CompositeColumn, Ranking, ISortCriteria, Column, isMapAbleColumn, mappingFunctions} from 'lineupjs';
+import {EngineRenderer, TaggleRenderer, ADialog, NumberColumn, LocalDataProvider, StackColumn, ScriptColumn, OrdinalColumn, CompositeColumn, Ranking, ISortCriteria, Column, isMapAbleColumn, mappingFunctions} from 'lineupjs';
 import {resolveImmediately} from 'phovea_core/src';
 import i18n from 'phovea_core/src/i18n';
 
@@ -638,12 +638,21 @@ function untrackRanking(ranking: Ranking) {
 /**
  * Clueifies the given LineUp instance. Adds event listeners to track add and remove rankings
  * from the local data provider and adds event listeners for ranking events.
+ * @param lineup: The LineUp instance
  * @param objectRef The object reference that contains the LineUp data provider
  * @param graph The provenance graph where the events should be tracked into
  * @returns Returns a promise that is waiting for the object reference (LineUp instance)
  */
-export async function clueify(objectRef: IObjectRef<IViewProvider>, graph: ProvenanceGraph): Promise<void> {
+export async function clueify(lineup: EngineRenderer | TaggleRenderer, objectRef: IObjectRef<IViewProvider>, graph: ProvenanceGraph): Promise<void> {
   const p = await resolveImmediately((await objectRef.v).data);
+
+  lineup.on(`${EngineRenderer.EVENT_DIALOG_OPENED}.track`, (dialog: ADialog) => {
+    console.log('dialog opened', dialog);
+  });
+
+  lineup.on(`${EngineRenderer.EVENT_DIALOG_CLOSED}.track`, (dialog: ADialog, action: 'cancel' | 'confirm') => {
+    console.log('dialog closed', dialog, action);
+  });
 
   p.on(`${LocalDataProvider.EVENT_ADD_RANKING}.track`, (ranking: Ranking, index: number) => {
     if (ignore(LocalDataProvider.EVENT_ADD_RANKING, objectRef)) {

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -604,7 +604,6 @@ function trackRanking(lineup: EngineRenderer | TaggleRenderer, provider: LocalDa
   // buffer it and execute when the confirm button is clicked on the dialog.
   // If a dialog contains multiple actions like the visualization dialog save all three actions and execute on confirm.
   const bufferLivePreviewActions = (action: IBufferedAction, initialValue: any) => {
-    console.log('Current Actions', bufferedActions);
     bufferedActions.set(action.name, action);
     if (initialStates.has(action.name)) {
       return;
@@ -681,7 +680,6 @@ function trackRanking(lineup: EngineRenderer | TaggleRenderer, provider: LocalDa
   });
 
   ranking.on(`${Ranking.EVENT_GROUP_CRITERIA_CHANGED}.track`, (old: Column[], newValue: Column[]) => {
-    console.log('here')
     const execute = (initialState: Column[] = []) => {
       if (ignore(Ranking.EVENT_GROUP_CRITERIA_CHANGED, objectRef)) {
         return;

--- a/src/styles/_view_lineup.scss
+++ b/src/styles/_view_lineup.scss
@@ -11,13 +11,15 @@
     line-height: 1;
   }
 
-  > div {
+  // Select only first div containing the `lineup-engine`.
+  // Don't select the `div.lu-backdrop` element
+  > div:first-child() {
     flex: 1 1 auto;
     position: relative;
   }
 
   &.overview-detail {
-    > div {
+    > div:first-child() {
       display: flex;
       flex-direction: column;
 

--- a/src/styles/_view_lineup.scss
+++ b/src/styles/_view_lineup.scss
@@ -12,7 +12,8 @@
   }
 
   // Select only first div containing the `lineup-engine`.
-  // Don't select the `div.lu-backdrop` element
+  // Do not select the `div.lu-backdrop` element,
+  // which is moved one level up in the DOM tree in ARankingView.ts
   > div:first-child() {
     flex: 1 1 auto;
     position: relative;


### PR DESCRIPTION
Closes datavisyn/tdp_core#346

## Summary
* To simplify the implementation we decided to integrate  the **lodash** library, instead of writing
our own function to check for deep equality. 
* Refactored the actions that have a **live-preview** to not execute immediately, but instead
to run only when their corresponding dialog has been confirmed.


## Known issues and behaviors
### Open dialog + SidePanel action
Clicking on an action on the SidePanel when a dialog is open, does not execute the action.

To resolve this issue we extended the blurring effect of the ranking when a dialog is opened to
include the SidePanel.

### Traversing the prov tree node with an open dialog
When clicking on an action in the provenance graph node and a dialog is open in the ranking, the action does not get executed but buffered.

To resolve this issue we close all open dialogs when an action is clicked on, using the LineUp
**DialogManager**.

### Reset all filters

Click on the _reset all filters_ button will push multiple filter actions to the provenance graph, because LineUp is resetting each column individiually and trigger multiple filter events. Hence, going back one state in the provenance graph will only restore a single filter and **not** all filters at once.

![ordino-reset-all-filter](https://user-images.githubusercontent.com/5851088/78985419-0a9a9580-7b29-11ea-873a-9eae0ffc6dde.gif)

A possible solution would be the implementation of compound actions that buffer multiple events and execute them in one go. However, that would require the extension of the provenance tracking.


