### PR TITLE
Derive set column categories automatically

### DIFF
--- a/tdp_core/db.py
+++ b/tdp_core/db.py
@@ -483,7 +483,7 @@ def derive_columns(table_name, engine, columns=None):
             separated_categories = [category.split(separator) for category in categories]
             # flatten array
             categories = list(set([category for sublist in separated_categories for category in sublist]))
-            categories.sort() # sort list to avoid random order with each run
+            categories.sort()  # sort list to avoid random order with each run
         columns[col]['categories'] = categories
 
   return columns

--- a/tdp_core/db.py
+++ b/tdp_core/db.py
@@ -483,6 +483,7 @@ def derive_columns(table_name, engine, columns=None):
             separated_categories = [category.split(separator) for category in categories]
             # flatten array
             categories = list(set([category for sublist in separated_categories for category in sublist]))
+            categories.sort() # sort list to avoid random order with each run
         columns[col]['categories'] = categories
 
   return columns

--- a/tdp_core/db.py
+++ b/tdp_core/db.py
@@ -461,7 +461,7 @@ def derive_columns(table_name, engine, columns=None):
   # derive the missing domains and categories
   number_columns = [k for k, col in columns.items() if
                     col['type'] == 'number' and ('min' not in col or 'max' not in col)]
-  categorical_columns = [k for k, col in columns.items() if col['type'] == 'categorical' and 'categories' not in col]
+  categorical_columns = [k for k, col in columns.items() if (col['type'] == 'categorical' or col['type'] == 'set') and 'categories' not in col]
   if number_columns or categorical_columns:
     with session(engine) as s:
       if number_columns:
@@ -477,7 +477,13 @@ def derive_columns(table_name, engine, columns=None):
           template += """ AND {col} <> ''"""
         template += """ ORDER BY {col} ASC"""
         cats = s.execute(template.format(col=col, table=table_name))
-        columns[col]['categories'] = [str(r['cat']) for r in cats if r['cat'] is not None]
+        categories = [str(r['cat']) for r in cats if r['cat'] is not None]
+        if columns[col]['type'] == 'set':
+            separator = getattr(columns[col], 'separator', ';')
+            separated_categories = [category.split(separator) for category in categories]
+            # flatten array
+            categories = list(set([category for sublist in separated_categories for category in sublist]))
+        columns[col]['categories'] = categories
 
   return columns
 


### PR DESCRIPTION
### Summary
It would be nice to have the feature to derive `set columns` categories in the backend as is the 
case for categorical columns when calling the` DBViewBuilder.derive_columns()` method.

This feature is especially beneficial when the categories of the column **depend** on the selected IDs from the previous view.
