### PR TITLE
Fix overlapping entries in add column dialog

### DIFF
--- a/src/styles/_view_lineup.scss
+++ b/src/styles/_view_lineup.scss
@@ -362,7 +362,7 @@ $lu_assets: "~lineupjs/src/assets";
           left: -15em;
           z-index: 2;
 
-          ul {
+          > ul {
             max-height: 50vh;
           }
         }


### PR DESCRIPTION
Fixes datavisyn/tdp_core#330. 
It is already fixed in the Lineup#4 branch (https://github.com/datavisyn/tdp_core/commit/b5fc87f8ef3f3f139811c1b2c76f50efc306cfe5), but we need the change in current develop as well. 