### PR TITLE
Added builtLineUp hook propagation in AEmbeddedRanking

### DIFF
--- a/src/base/AEmbeddedRanking.ts
+++ b/src/base/AEmbeddedRanking.ts
@@ -88,6 +88,10 @@ export abstract class AEmbeddedRanking<T extends IRow> implements IViewProvider 
         }
       }
 
+      protected builtLineUp(lineup: LocalDataProvider) {
+        that.builtLineUp(lineup);
+      }
+
       protected setLineUpData(rows: IRow[]) {
         super.setLineUpData(rows);
         // maybe trigger a score reload if needed
@@ -147,6 +151,10 @@ export abstract class AEmbeddedRanking<T extends IRow> implements IViewProvider 
   }
 
   protected initialized() {
+    // hook
+  }
+
+  protected builtLineUp(lineup: LocalDataProvider) {
     // hook
   }
 


### PR DESCRIPTION
_Draft because I don't think we should implement all features like this... see #370 for details_

**Usage:**
After calling `this.rebuild('...')` in your ranking, the overwritten `builtLineUp(lineup)` will be triggered after everything is done. 