### PR TITLE
Persist expand/collapse state for aggregated groups in the provenance graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@types/select2": "4.0.44",
     "d3": "~3.5.17",
     "jquery": "~3.4.1",
-    "lineupjs": "github:lineupjs/lineupjs#sgratzl/aggregationrestore",
+    "lineupjs": "github:lineupjs/lineupjs#develop",
     "phovea_clue": "github:phovea/phovea_clue#develop",
     "select2": "~4.0.13",
     "select2-bootstrap-theme": "0.1.0-beta.9",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@types/select2": "4.0.44",
     "d3": "~3.5.17",
     "jquery": "~3.4.1",
-    "lineupjs": "github:lineupjs/lineupjs#develop",
+    "lineupjs": "github:lineupjs/lineupjs#sgratzl/aggregationrestore",
     "phovea_clue": "github:phovea/phovea_clue#develop",
     "select2": "~4.0.13",
     "select2-bootstrap-theme": "0.1.0-beta.9",

--- a/src/assets/locales/en/tdp.json
+++ b/src/assets/locales/en/tdp.json
@@ -183,7 +183,8 @@
         "setProperty": "Set Property {{prop}}",
         "addColumn": "Add Column",
         "removeColumn": "Remove Column",
-        "moveColumn": "Move Column"
+        "moveColumn": "Move Column",
+        "changeAggregation":"Change Aggregation"
       },
 
       "export": {

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -227,10 +227,10 @@ interface IAggregationParameter {
   /**
    * Aggregation value
    */
-  value: number;
+  value: number | number[];
 }
 
-export function setAggregation(provider: IObjectRef<any>, rid: number, group: string | string[], value: number) {
+export function setAggregation(provider: IObjectRef<any>, rid: number, group: string | string[], value: number | number[]) {
   return action(meta(i18n.t('tdp:core.lineup.cmds.changeAggregation'), cat.layout, op.update), LineUpCmds.CMD_SET_AGGREGATION, setAggregationImpl, [provider], <IAggregationParameter>{
     rid,
     group,
@@ -245,12 +245,12 @@ export async function setAggregationImpl(inputs: IObjectRef<any>[], parameter: I
   const waitForAggregated = dirtyRankingWaiter(ranking);
   ignoreNext = LocalDataProvider.EVENT_GROUP_AGGREGATION_CHANGED;
 
-  let inverseValue: number;
+  let inverseValue: number | number[];
 
   if (Array.isArray(parameter.group)) {
     // use `filter()` for multiple groups
     const groups = ranking.getFlatGroups().filter((d) => parameter.group.includes(d.name));
-    inverseValue = groups.map((group) => p.getTopNAggregated(ranking, group))[0]; // TODO: avoid `previousTopN[0]`; requires support for `number[]` in LineUp `setTopNAggregated()`
+    inverseValue = groups.map((group) => p.getTopNAggregated(ranking, group));
     p.setTopNAggregated(ranking, groups, parameter.value);
 
   } else {
@@ -819,10 +819,9 @@ function trackRanking(lineup: EngineRenderer | TaggleRenderer, provider: LocalDa
 
     const rid = rankingId(provider, ranking);
     const groupNames = Array.isArray(groups) ? groups.map((g) => g.name) : groups.name;
-    const old = Array.isArray(previousTopN) ? previousTopN[0] : previousTopN; // TODO: avoid `previousTopN[0]`; requires support for `number[]` in LineUp `setTopNAggregated()`
 
     graph.pushWithResult(setAggregation(objectRef, rid, groupNames, currentTopN), {
-      inverse: setAggregation(objectRef, rid, groupNames, old)
+      inverse: setAggregation(objectRef, rid, groupNames, previousTopN)
     });
   });
 

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -218,7 +218,7 @@ interface IAggregationParameter {
    * Ranking ID
    */
   rid: number;
-  
+
   /**
    * Single or multiple group names
    */
@@ -822,7 +822,7 @@ function trackRanking(lineup: EngineRenderer | TaggleRenderer, provider: LocalDa
     const old = Array.isArray(previousTopN) ? previousTopN[0] : previousTopN; // TODO: avoid `previousTopN[0]`; requires support for `number[]` in LineUp `setTopNAggregated()`
 
     graph.pushWithResult(setAggregation(objectRef, rid, groupNames, currentTopN), {
-      inverse: setAggregation(objectRef, rid, groupNames, old) 
+      inverse: setAggregation(objectRef, rid, groupNames, old)
     });
   });
 

--- a/src/phovea.ts
+++ b/src/phovea.ts
@@ -72,6 +72,12 @@ export default function (registry: IRegistry) {
       action: 'setRankingSortCriteria'
     }
   });
+  actionFunction('lineupSetAggregation', 'setAggregationImpl', () => System.import('./lineup/internal/cmds'), {
+    analytics: {
+      category: 'lineup',
+      action: 'setAggregation'
+    }
+  });
   actionFunction('lineupSetSortCriteria', 'setSortCriteriaImpl', () => System.import('./lineup/internal/cmds'), {
     analytics: {
       category: 'lineup',


### PR DESCRIPTION
Depends on lineupjs/lineupjs#353
Closes datavisyn/tdp_core#378

### Summary
* Added clue commands to track the aggregation state of the groups in the provenance graph

### Screenshot
![aggregate_column](https://user-images.githubusercontent.com/51322092/85258702-3959b400-b468-11ea-935d-5cd4f1f4e7fd.gif)

@thinkh When you have time, to complete this PR, we need to discuss how to handle 2+ levels nested groups. The groups object contains circular references which causes `JSON.stringify()` to fail in phovea_clue.