### PR TITLE
Fix truncated select2 and select3 placholder

### DIFF
--- a/src/styles/_select2.scss
+++ b/src/styles/_select2.scss
@@ -43,4 +43,13 @@
   .select2-dropdown {
     z-index: 2051;
   }
+
+  // fix select2 placeholder cut-off from https://github.com/select2/select2/pull/4898#issuecomment-408568031
+  .select2-container .select2-selection__rendered > *:first-child.select2-search--inline {
+    width: 100% !important;
+
+    .select2-search__field {
+      width: 100% !important;
+    }
+  }
 }


### PR DESCRIPTION
Fixes #381

Related PR: https://github.com/Caleydo/tdp_gene/pull/135

### Summary

Solution from https://github.com/select2/select2/pull/4898#issuecomment-408568031

![grafik](https://user-images.githubusercontent.com/5851088/85271812-97dc5d80-b47b-11ea-8e45-7af7f9ca9a23.png)

![grafik](https://user-images.githubusercontent.com/5851088/85271859-ac205a80-b47b-11ea-921b-e6cc912c9e2d.png)

![grafik](https://user-images.githubusercontent.com/5851088/85271910-bc383a00-b47b-11ea-92ad-ea71c09b0a80.png)


@oltionchampari Please check if it works for you in Ordino

@lehnerchristian Please cross-check if it works in some other apps.
