### PR TITLE
Use data values instead of formulas for XSLX files

### DIFF
--- a/tdp_core/xlsx.py
+++ b/tdp_core/xlsx.py
@@ -44,7 +44,7 @@ def _xlsx2json():
   if not file:
     abort(403, 'missing file')
 
-  wb = load_workbook(file, read_only=True)
+  wb = load_workbook(file, read_only=True, data_only=True)
 
   def convert_row(row, cols):
     result = {}
@@ -82,7 +82,7 @@ def _xlsx2json_array():
   if not file:
     abort(403, 'missing file')
 
-  wb = load_workbook(file, read_only=True)
+  wb = load_workbook(file, read_only=True, data_only=True)
 
   def convert_row(row):
     return [_convert_value(cell.value) for cell in row]


### PR DESCRIPTION
Fixes #383

Requires https://github.com/phovea/phovea_importer/pull/113

### Summary

Solved by adding the `data_only=True` flag to `load_workbook()`. From the [openpyxl documentation](https://openpyxl.readthedocs.io/en/stable/usage.html#read-an-existing-workbook):

> There are several flags that can be used in load_workbook.
> * _data_only_ controls whether cells with formulae have either the formula (default) or the value stored the last time Excel read the sheet.
> * _keep_vba_ controls whether any Visual Basic elements are preserved or not (default). If they are preserved they are still not editable.

The response from the server shows the correct data values

![grafik](https://user-images.githubusercontent.com/5851088/85852450-e9a12280-b7b0-11ea-92e2-6570b4ba51b7.png)


### How to test

The [FormulaTest.xlsx](https://github.com/datavisyn/tdp_core/files/4836451/FormulaTest.xlsx) uses SUM formulae for some value cells.

![grafik](https://user-images.githubusercontent.com/5851088/85849034-801e1580-b7aa-11ea-84c6-e2d80a0c1168.png)

* Download the file
* Open Ordino
* Upload the file

![grafik](https://user-images.githubusercontent.com/5851088/85854993-c3ca4c80-b7b5-11ea-9eb8-46b0ebdde6f8.png)



