### PR TITLE
Track in provenance graph the`groupingChanged` LineUp event

### DIFF
--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -12,13 +12,14 @@ import {isEqual} from 'lodash';
 
 // used for function calls in the context of tracking or untracking actions in the provenance graph in order to get a consistent defintion of the used strings
 enum LineUpTrackAndUntrackActions {
+  ChangedSuffix = 'Changed.track', // used as suffix in `untrack()`
+
   metaData = 'metaData',
   filter = 'filter',
   rendererType = 'rendererType', // important: the corresponding functions in LineUp are called `getRenderer` and `setRenderer` (see `setColumnImpl()` below)
   groupRenderer = 'groupRenderer',
   summaryRenderer = 'summaryRenderer',
   sortMethod = 'sortMethod',
-  ChangedFilter = 'Changed.filter',
   width = 'width',
   grouping = 'grouping', // important: the corresponding functions in LineUp vary on the column type (see `setColumnImpl()` below)
   mapping = 'mapping',
@@ -462,7 +463,7 @@ function recordPropertyChange(source: Column | Ranking, provider: LocalDataProvi
     execute(); // execute immediately
   };
 
-  source.on(`${property}Changed.track`, delayed > 0 ? delayedCall(eventListenerFunction, delayed) : eventListenerFunction);
+  source.on(suffix(LineUpTrackAndUntrackActions.ChangedSuffix, property), delayed > 0 ? delayedCall(eventListenerFunction, delayed) : eventListenerFunction);
 }
 
 /**
@@ -560,7 +561,7 @@ function trackColumn(provider: LocalDataProvider, objectRef: IObjectRef<IViewPro
  * @param col Column
  */
 function untrackColumn(col: Column) {
-  col.on(suffix(LineUpTrackAndUntrackActions.ChangedFilter, LineUpTrackAndUntrackActions.metaData, LineUpTrackAndUntrackActions.filter, LineUpTrackAndUntrackActions.width, LineUpTrackAndUntrackActions.rendererType, LineUpTrackAndUntrackActions.groupRenderer, LineUpTrackAndUntrackActions.summaryRenderer, LineUpTrackAndUntrackActions.sortMethod), null);
+  col.on(suffix(LineUpTrackAndUntrackActions.ChangedSuffix, LineUpTrackAndUntrackActions.metaData, LineUpTrackAndUntrackActions.filter, LineUpTrackAndUntrackActions.width, LineUpTrackAndUntrackActions.rendererType, LineUpTrackAndUntrackActions.groupRenderer, LineUpTrackAndUntrackActions.summaryRenderer, LineUpTrackAndUntrackActions.sortMethod), null);
 
   if (col instanceof CompositeColumn) {
     col.on([`${CompositeColumn.EVENT_ADD_COLUMN}.track`, `${CompositeColumn.EVENT_REMOVE_COLUMN}.track`, `${CompositeColumn.EVENT_MOVE_COLUMN}.track`], null);

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -21,6 +21,8 @@ enum LineUpTrackAndUntrackActions {
   ChangedFilter = 'Changed.filter',
   width = 'width',
   grouping = 'grouping', // important: the corresponding functions in LineUp vary on the column type (see `setColumnImpl()` below)
+  mapping = 'mapping',
+  script = 'script'
 }
 
 // Actions that originate from LineUp
@@ -224,8 +226,10 @@ export async function setColumnImpl(inputs: IObjectRef<any>[], parameter: any) {
   if (parameter.path) {
     source = ranking.findByPath(parameter.path);
   }
+
   ignoreNext = `${parameter.prop}Changed`;
-  if (parameter.prop === 'mapping' && source instanceof Column && isMapAbleColumn(source)) {
+
+  if (parameter.prop === LineUpTrackAndUntrackActions.mapping && source instanceof Column && isMapAbleColumn(source)) {
     bak = source.getMapping().toJSON();
     if (parameter.value.type.includes('linear')) {
       parameter.value.type = 'linear';
@@ -476,7 +480,7 @@ function trackColumn(provider: LocalDataProvider, objectRef: IObjectRef<IViewPro
   recordPropertyChange(col, provider, objectRef, graph, LineUpTrackAndUntrackActions.groupRenderer, null, bufferOrExecute);
   recordPropertyChange(col, provider, objectRef, graph, LineUpTrackAndUntrackActions.summaryRenderer, null, bufferOrExecute);
   recordPropertyChange(col, provider, objectRef, graph, LineUpTrackAndUntrackActions.sortMethod, null, bufferOrExecute);
-  //recordPropertyChange(col, provider, lineup, graph, 'width', 100);
+  //recordPropertyChange(col, provider, lineup, graph, LineUpTrackAndUntrackActions.width, 100);
 
   if (col instanceof CompositeColumn) {
     col.on(`${CompositeColumn.EVENT_ADD_COLUMN}.track`, (column, index: number) => {
@@ -535,16 +539,16 @@ function trackColumn(provider: LocalDataProvider, objectRef: IObjectRef<IViewPro
       }
       const rid = rankingId(provider, col.findMyRanker());
       const path = col.fqpath;
-      graph.pushWithResult(setColumn(objectRef, rid, path, 'mapping', newValue.toJSON()), {
-        inverse: setColumn(objectRef, rid, path, 'mapping', old.toJSON())
+      graph.pushWithResult(setColumn(objectRef, rid, path, LineUpTrackAndUntrackActions.mapping, newValue.toJSON()), {
+        inverse: setColumn(objectRef, rid, path, LineUpTrackAndUntrackActions.mapping, old.toJSON())
       });
     });
 
   } else if (col instanceof ScriptColumn) {
-    recordPropertyChange(col, provider, objectRef, graph, 'script', null, bufferOrExecute);
+    recordPropertyChange(col, provider, objectRef, graph, LineUpTrackAndUntrackActions.script, null, bufferOrExecute);
 
   } else if (col instanceof OrdinalColumn) {
-    recordPropertyChange(col, provider, objectRef, graph, 'mapping');
+    recordPropertyChange(col, provider, objectRef, graph, LineUpTrackAndUntrackActions.mapping);
 
   } else if (col instanceof StringColumn || col instanceof DateColumn) {
     recordPropertyChange(col, provider, objectRef, graph, LineUpTrackAndUntrackActions.grouping, null, bufferOrExecute);

--- a/src/lineup/internal/cmds.ts
+++ b/src/lineup/internal/cmds.ts
@@ -20,7 +20,7 @@ enum LineUpTrackAndUntrackActions {
   sortMethod = 'sortMethod',
   ChangedFilter = 'Changed.filter',
   width = 'width',
-  grouping = 'grouping'
+  grouping = 'grouping', // important: the corresponding functions in LineUp vary on the column type (see `setColumnImpl()` below)
 }
 
 // Actions that originate from LineUp
@@ -418,7 +418,7 @@ function recordPropertyChange(source: Column | Ranking, provider: LocalDataProvi
         newValue = isLineUpStringFilter(newValue) ? serializeLineUpFilter(newValue) : newValue; // serialize possible RegExp object to be properly stored as provenance graph
       }
 
-      if (property === LineUpTrackAndUntrackActions.grouping && source instanceof StringColumn) {
+      if (property === LineUpTrackAndUntrackActions.grouping && source instanceof StringColumn) { // only string columns can be grouped by RegExp
         newValue = serializeGroupByValue(newValue); // serialize possible RegExp object to be properly stored as provenance graph
       }
 
@@ -527,7 +527,7 @@ function trackColumn(provider: LocalDataProvider, objectRef: IObjectRef<IViewPro
 
   } else if (col instanceof NumberColumn) {
 
-    recordPropertyChange(col, provider, objectRef, graph, 'grouping', null, bufferOrExecute);
+    recordPropertyChange(col, provider, objectRef, graph, LineUpTrackAndUntrackActions.grouping, null, bufferOrExecute);
 
     col.on(`${NumberColumn.EVENT_MAPPING_CHANGED}.track`, (old, newValue) => {
       if (ignore(NumberColumn.EVENT_MAPPING_CHANGED, objectRef)) {
@@ -547,7 +547,7 @@ function trackColumn(provider: LocalDataProvider, objectRef: IObjectRef<IViewPro
     recordPropertyChange(col, provider, objectRef, graph, 'mapping');
 
   } else if (col instanceof StringColumn || col instanceof DateColumn) {
-    recordPropertyChange(col, provider, objectRef, graph, 'grouping', null, bufferOrExecute);
+    recordPropertyChange(col, provider, objectRef, graph, LineUpTrackAndUntrackActions.grouping, null, bufferOrExecute);
   }
 }
 

--- a/src/lineup/internal/cmds/filter.ts
+++ b/src/lineup/internal/cmds/filter.ts
@@ -1,3 +1,5 @@
+import {IStringGroupCriteria} from 'lineupjs';
+
 /**
  * Basic LineUp string filter values
  */
@@ -172,4 +174,42 @@ export function restoreLineUpFilter(filter: LineUpStringFilterValue | IRegExpFil
   }
 
   throw new Error('Unknown LineUp filter format. Unable to restore the given filter.');
+}
+
+/**
+ * String column's group criterias as stored in the provenance graph.
+ */
+interface ISerializedStringGroupCriteria extends IStringGroupCriteria {
+  values: string[];
+}
+
+/**
+ * Serializes LineUp StringColumn's `Group By` dialog's values, which can contain a RegExp objects to a string.
+ * The return value of this function can be passed to `JSON.stringify()` and stored in the provenance graph.
+ * @param groupBy Value returned from the `Group By` dialog
+ */
+export function serializeGroupByValue(groupBy: IStringGroupCriteria) {
+  const {type, values} = groupBy;
+  if (type === 'regex') {
+    return {
+      type,
+      values: values.map((value) => value.toString())
+    };
+  }
+  return groupBy;
+}
+
+/**
+ * Restores LineUp StringColumn's Group By` dialog's values from the provenance graph and returns an `IStringGroupCriteria`.
+ * @param groupBy Value as saved in the provenance graph.
+ */
+export function restoreGroupByValue(groupBy: ISerializedStringGroupCriteria) {
+  const {type, values} = groupBy;
+  if (type === 'regex') {
+    return {
+      type,
+      values: values.map((value) => restoreRegExp(value as string))
+    };
+  }
+  return groupBy;
 }

--- a/tests/lineup/internal/cmds/filter.test.ts
+++ b/tests/lineup/internal/cmds/filter.test.ts
@@ -1,5 +1,6 @@
 /// <reference types="jest" />
-import {serializeLineUpFilter, restoreLineUpFilter, isSerializedFilter, isLineUpStringFilter, restoreRegExp} from '../../../../src/lineup/internal/cmds/filter';
+import {serializeLineUpFilter, restoreLineUpFilter, isSerializedFilter, isLineUpStringFilter, restoreRegExp, serializeGroupByValue, restoreGroupByValue} from '../../../../src/lineup/internal/cmds/filter';
+import {EStringGroupCriteriaType} from 'lineupjs';
 
 // The following tests worked with LineUp v3.
 // With LineUp v4 the filter object changed
@@ -134,6 +135,83 @@ describe('Restore LineUp filter from provenance graph', () => {
     expect(() => {
       restoreLineUpFilter(<any>123456789); // typecast to pass unknown format
     }).toThrowError(new Error('Unknown LineUp filter format. Unable to restore the given filter.'));
+  });
+});
+
+describe('Serialize LineUp `Group by` dialog\'s value', () => {
+  it('object with `value: []`, `type: value`', () => {
+    const groupByValue = {type: EStringGroupCriteriaType.value, values: []};
+    const expectedValue = groupByValue;
+
+    expect(serializeGroupByValue(groupByValue)).toMatchObject(expectedValue);
+  });
+
+  it('object with `value: [A, B]`, `type: startsWith`', () => {
+    const groupByValue = {type: EStringGroupCriteriaType.startsWith, values: ['A', 'B']};
+    const expectedValue = groupByValue;
+
+    expect(serializeGroupByValue(groupByValue)).toMatchObject(expectedValue);
+  });
+
+  it('object with `value: [/abc/, /efg/]`, `type: regex`', () => {
+    const groupByValue = {type: EStringGroupCriteriaType.regex, values: [/abc/, /efg/]};
+    const expectedValue = {type: EStringGroupCriteriaType.regex, values: ['/abc/', '/efg/']};
+    const incorrectValue = {type: EStringGroupCriteriaType.regex, values: []};
+
+    expect(serializeGroupByValue(groupByValue)).toMatchObject(expectedValue);
+    expect(serializeGroupByValue(groupByValue)).not.toMatchObject(incorrectValue);
+  });
+
+  it('object with `value: []`, `type: regex`', () => {
+    const groupByValue = {type: EStringGroupCriteriaType.regex, values: []};
+    const expectedValue = groupByValue;
+    const incorrectValue = {type: EStringGroupCriteriaType.regex, values: [/abc/]};
+
+    expect(serializeGroupByValue(groupByValue)).toMatchObject(expectedValue);
+    expect(serializeGroupByValue(groupByValue)).not.toMatchObject(incorrectValue);
+  });
+});
+
+describe('Restore LineUp `Group By` dialog\'s value from provenance graph', () => {
+  it('object with `value: []`, `type: value`', () => {
+    const groupByValue = {type: EStringGroupCriteriaType.value, values: []};
+    const expectedValue = groupByValue;
+
+    expect(restoreGroupByValue(groupByValue)).toMatchObject(expectedValue);
+  });
+
+  it('object with `value: [A, B]`, `type: startsWith`', () => {
+    const groupByValue = {type: EStringGroupCriteriaType.startsWith, values: ['A', 'B']};
+    const expectedValue = groupByValue;
+
+    expect(restoreGroupByValue(groupByValue)).toMatchObject(expectedValue);
+  });
+
+  it('object with `value: ["/abc/", "/efg/"]`, `type: regex`', () => {
+    const groupByValue = {type: EStringGroupCriteriaType.regex, values: ['/abc/', '/efg/']};
+    const expectedValue = {type: EStringGroupCriteriaType.regex, values: [/abc/, /efg/]};
+    const incorrectValue = groupByValue;
+
+    expect(restoreGroupByValue(groupByValue)).toMatchObject(expectedValue);
+    expect(restoreGroupByValue(groupByValue)).not.toMatchObject(incorrectValue);
+  });
+
+  it('object with `value: ["/^abc$/"]`, `type: regex`', () => {
+    const groupByValue = {type: EStringGroupCriteriaType.regex, values: ['/^abc$/']};
+    const expectedValue = {type: EStringGroupCriteriaType.regex, values: [/^abc$/]};
+    const incorrectValue = groupByValue;
+
+    expect(restoreGroupByValue(groupByValue)).toMatchObject(expectedValue);
+    expect(restoreGroupByValue(groupByValue)).not.toMatchObject(incorrectValue);
+  });
+
+  it('object with `value: []`, `type: regex`', () => {
+    const groupByValue = {type: EStringGroupCriteriaType.regex, values: []};
+    const expectedValue = groupByValue;
+    const incorrectValue = {type: EStringGroupCriteriaType.regex, values: [/abc/]};
+
+    expect(restoreGroupByValue(groupByValue)).toMatchObject(expectedValue);
+    expect(restoreGroupByValue(groupByValue)).not.toMatchObject(incorrectValue);
   });
 });
 


### PR DESCRIPTION
Closes datavisyn/tdp_core#379

### Summary
* Added a new cmd `Set Property grouping`.
* The StringColumn's groupBy value can be a RegExp so it was necessary to serialize and deserialize the value similar to the RegExp filter value.
* Tested the StringColumn and NumberColumn implementation. Unfortunately i could not find a DateColumn to test the functionality. @thinkh Could you maybe test this somehow?

The events `StringColumn.EVENT_GROUPING_CHANGED` and `Ranking.EVENT_GROUP_CRITERIA_CHANGED`, 
never intersect apart from when the groupBy dialog is set for the first time.

### Screenshot

![grafik](https://user-images.githubusercontent.com/51322092/85858064-41448b80-b7bb-11ea-8a1f-922433a47641.gif)
