### PR TITLE
Disable propagation of aggregation state for child groups in `ARankingView`

### DIFF
--- a/src/lineup/ARankingView.ts
+++ b/src/lineup/ARankingView.ts
@@ -267,7 +267,6 @@ export abstract class ARankingView extends AView {
 
 
     this.provider = new LocalDataProvider([], [], this.options.customProviderOptions);
-    console.log(this.provider.getAggregationStrategy());
     // hack in for providing the data provider within the graph
     // the reason for `this.context.ref.value.data` is that from the sub-class the `this` context (reference) is set to `this.context.ref.value` through the provenance graph
     // so by setting `.data` on the reference it is actually set by the sub-class (e.g. by the `AEmbeddedRanking` view)

--- a/src/lineup/ARankingView.ts
+++ b/src/lineup/ARankingView.ts
@@ -231,7 +231,8 @@ export abstract class ARankingView extends AView {
     customProviderOptions: {
       maxNestedSortingCriteria: Infinity,
       maxGroupColumns: Infinity,
-      filterGlobally: true
+      filterGlobally: true,
+      propagateAggregationState: false
     }
   };
 
@@ -266,6 +267,7 @@ export abstract class ARankingView extends AView {
 
 
     this.provider = new LocalDataProvider([], [], this.options.customProviderOptions);
+    console.log(this.provider.getAggregationStrategy());
     // hack in for providing the data provider within the graph
     // the reason for `this.context.ref.value.data` is that from the sub-class the `this` context (reference) is set to `this.context.ref.value` through the provenance graph
     // so by setting `.data` on the reference it is actually set by the sub-class (e.g. by the `AEmbeddedRanking` view)


### PR DESCRIPTION
Closes #386

Requires lineupjs/lineupjs#376

### Summary

**Before**

![ordino-propagate-grouping](https://user-images.githubusercontent.com/5851088/86772311-07457600-c054-11ea-93ab-f3b8dee3ed0a.gif)

**After**

![ordino-disable-propagate-grouping](https://user-images.githubusercontent.com/5851088/86772730-ddd91a00-c054-11ea-8699-34184a7d695d.gif)


@anita-steiner + @dg-datavisyn This PR changes the current default behavior in `ARankingView`. If this a problem for some apps I can integrate the change directly in Ordino (and not here in tdp_core).
