### PR TITLE
Changed CSS selector for main LineUp ranking

### DIFF
--- a/dist/scss/_view_lineup.scss
+++ b/dist/scss/_view_lineup.scss
@@ -11,7 +11,7 @@
     line-height: 1;
   }
 
-  > div {
+  > div:first-of-type {
     flex: 1 1 auto;
     position: relative;
   }

--- a/src/scss/_view_lineup.scss
+++ b/src/scss/_view_lineup.scss
@@ -11,7 +11,7 @@
     line-height: 1;
   }
 
-  > div {
+  > div:first-of-type {
     flex: 1 1 auto;
     position: relative;
   }


### PR DESCRIPTION
Previously, the style of the ranking was applied to *all* child divs of the `lineup` class, which interfered with the way the backdrop is treated now (as same level div). 