### PR TITLE
Merge the two different versions of _view_lineup.scss

### DIFF
--- a/dist/scss/_view_lineup.scss
+++ b/dist/scss/_view_lineup.scss
@@ -1,23 +1,27 @@
-@import "./vars";
-@import "~font-awesome/scss/variables";
-@import "~font-awesome/scss/mixins";
+@import './vars';
+@import '~font-awesome/scss/variables';
+@import '~font-awesome/scss/mixins';
 
 &.lineup {
   display: flex;
   flex-direction: row;
   height: 100%;
 
-  .lu-row {
+  .lu-row,
+  .le-tr {
     line-height: 1;
   }
 
+  // Select only first div containing the `lineup-engine`.
+  // Do not select the `div.lu-backdrop` element,
+  // which is moved one level up in the DOM tree in ARankingView.ts
   > div:first-of-type {
     flex: 1 1 auto;
     position: relative;
   }
 
   &.overview-detail {
-    > div {
+    > div:first-child() {
       display: flex;
       flex-direction: column;
 
@@ -73,7 +77,7 @@
   }
 }
 
-$lu_assets: "~lineupjs/src/assets";
+$lu_assets: '~lineupjs/src/assets';
 
 @at-root {
   .tdp-ranking-export-form {
@@ -106,14 +110,23 @@ $lu_assets: "~lineupjs/src/assets";
 
   .lu-side-panel {
     width: 100%;
+    height: 100%;
   }
 
   .lu-side-panel > main > section::before {
-    content: "Column Summaries";
+    content: 'Column Summaries';
   }
 
-  .lu-hierarchy .lu-search::before {
-    height: 19px;
+  .lu-hierarchy {
+    footer.lu-hierarchy-adder {
+      // the phovea_clue selector `body[data-clue='E'] footer` hides this footer
+      // so we must override it and display it explicitly
+      display: flex;
+    }
+
+    .lu-search::before {
+      height: 19px;
+    }
   }
 
   .lu-side-panel-wrapper {
@@ -197,6 +210,10 @@ $lu_assets: "~lineupjs/src/assets";
       position: relative;
       color: #ffd700;
 
+      &:hover {
+        z-index: 2;
+      }
+
       &::before {
         content: $fa-var-exclamation-triangle;
       }
@@ -230,14 +247,14 @@ $lu_assets: "~lineupjs/src/assets";
 
       // show the number of selected rows after the element
       li[data-num-selected-rows]::after {
-        content: " ("attr(data-num-selected-rows) ")";
+        content: ' ('attr(data-num-selected-rows) ')';
         display: inline;
       }
 
       // hide the dropdown-header and the next list point (= download link), if no rows are selected
       // note that this only works for a *single* link as after the header list item!
-      li[data-num-selected-rows="0"],
-      li[data-num-selected-rows="0"] + li {
+      li[data-num-selected-rows='0'],
+      li[data-num-selected-rows='0'] + li {
         display: none;
       }
     }
@@ -290,7 +307,22 @@ $lu_assets: "~lineupjs/src/assets";
         bottom: 0;
         right: 0;
         left: 0;
-        overflow-y: auto;
+        overflow: auto;
+
+        &.active {
+          display: flex;
+          flex-direction: column;
+        }
+
+        // Add scrollbar to SidePanel higher in the node tree
+        .lu-side-panel-main {
+          overflow-y: auto;
+          overflow-x: hidden;
+
+          .lu-side-panel-ranking-main {
+            overflow: visible;
+          }
+        }
       }
     }
 
@@ -347,7 +379,7 @@ $lu_assets: "~lineupjs/src/assets";
         }
 
         &.once::before {
-          content: "";
+          content: '';
           top: -30px;
           left: -20em;
           right: 0;
@@ -411,7 +443,7 @@ $lu_assets: "~lineupjs/src/assets";
       }
 
       &.once::before {
-        content: "";
+        content: '';
         top: -10px;
         left: -2.5em;
         right: -15em;

--- a/src/scss/_view_lineup.scss
+++ b/src/scss/_view_lineup.scss
@@ -1,23 +1,27 @@
-@import "./vars";
-@import "~font-awesome/scss/variables";
-@import "~font-awesome/scss/mixins";
+@import './vars';
+@import '~font-awesome/scss/variables';
+@import '~font-awesome/scss/mixins';
 
 &.lineup {
   display: flex;
   flex-direction: row;
   height: 100%;
 
-  .lu-row {
+  .lu-row,
+  .le-tr {
     line-height: 1;
   }
 
-  > div:first-of-type {
+  // Select only first div containing the `lineup-engine`.
+  // Do not select the `div.lu-backdrop` element,
+  // which is moved one level up in the DOM tree in ARankingView.ts
+  > div:first-child() {
     flex: 1 1 auto;
     position: relative;
   }
 
   &.overview-detail {
-    > div {
+    > div:first-child() {
       display: flex;
       flex-direction: column;
 
@@ -73,7 +77,7 @@
   }
 }
 
-$lu_assets: "~lineupjs/src/assets";
+$lu_assets: '~lineupjs/src/assets';
 
 @at-root {
   .tdp-ranking-export-form {
@@ -106,14 +110,23 @@ $lu_assets: "~lineupjs/src/assets";
 
   .lu-side-panel {
     width: 100%;
+    height: 100%;
   }
 
   .lu-side-panel > main > section::before {
-    content: "Column Summaries";
+    content: 'Column Summaries';
   }
 
-  .lu-hierarchy .lu-search::before {
-    height: 19px;
+  .lu-hierarchy {
+    footer.lu-hierarchy-adder {
+      // the phovea_clue selector `body[data-clue='E'] footer` hides this footer
+      // so we must override it and display it explicitly
+      display: flex;
+    }
+
+    .lu-search::before {
+      height: 19px;
+    }
   }
 
   .lu-side-panel-wrapper {
@@ -197,6 +210,10 @@ $lu_assets: "~lineupjs/src/assets";
       position: relative;
       color: #ffd700;
 
+      &:hover {
+        z-index: 2;
+      }
+
       &::before {
         content: $fa-var-exclamation-triangle;
       }
@@ -230,14 +247,14 @@ $lu_assets: "~lineupjs/src/assets";
 
       // show the number of selected rows after the element
       li[data-num-selected-rows]::after {
-        content: " ("attr(data-num-selected-rows) ")";
+        content: ' ('attr(data-num-selected-rows) ')';
         display: inline;
       }
 
       // hide the dropdown-header and the next list point (= download link), if no rows are selected
       // note that this only works for a *single* link as after the header list item!
-      li[data-num-selected-rows="0"],
-      li[data-num-selected-rows="0"] + li {
+      li[data-num-selected-rows='0'],
+      li[data-num-selected-rows='0'] + li {
         display: none;
       }
     }
@@ -290,7 +307,22 @@ $lu_assets: "~lineupjs/src/assets";
         bottom: 0;
         right: 0;
         left: 0;
-        overflow-y: auto;
+        overflow: auto;
+
+        &.active {
+          display: flex;
+          flex-direction: column;
+        }
+
+        // Add scrollbar to SidePanel higher in the node tree
+        .lu-side-panel-main {
+          overflow-y: auto;
+          overflow-x: hidden;
+
+          .lu-side-panel-ranking-main {
+            overflow: visible;
+          }
+        }
       }
     }
 
@@ -347,7 +379,7 @@ $lu_assets: "~lineupjs/src/assets";
         }
 
         &.once::before {
-          content: "";
+          content: '';
           top: -30px;
           left: -20em;
           right: 0;
@@ -411,7 +443,7 @@ $lu_assets: "~lineupjs/src/assets";
       }
 
       &.once::before {
-        content: "";
+        content: '';
         top: -10px;
         left: -2.5em;
         right: -15em;

--- a/src/scss/_view_lineup.scss
+++ b/src/scss/_view_lineup.scss
@@ -15,7 +15,7 @@
   // Select only first div containing the `lineup-engine`.
   // Do not select the `div.lu-backdrop` element,
   // which is moved one level up in the DOM tree in ARankingView.ts
-  > div:first-child() {
+  > div:first-of-type {
     flex: 1 1 auto;
     position: relative;
   }


### PR DESCRIPTION
Apparently the file `_view_lineup.scss` exists with two different histories. The current develop branch is missing the changes made to the file the past year, that are present in the  file with alternative history.

develop branch: https://github.com/datavisyn/tdp_core/commits/develop/src/styles/_view_lineup.scss
alternative history: https://github.com/datavisyn/tdp_core/commits/b9d40d04c23ef53fd2693ec8d3f93da1068a7f2d/src/styles/_view_lineup.scss
last common commit is 768cf0ce5c7c1f402b9867a2a1a95990c4ca65f7 from Aug 28, 2019. 

This PR adds the changes missing from the current `_view_lineup.scss` of the develop branch.
Tested branch in ordino and everything looks as it should