### PR TITLE
Improve locale strings for better UX

### DIFF
--- a/dist/locales/en/tdp.json
+++ b/dist/locales/en/tdp.json
@@ -187,7 +187,7 @@
                 "tsv": "TSV (tab separated)",
                 "csvColon": "CSV (semicolon separated)",
                 "json": "JSON",
-                "excel": "Save in Microsoft Excel format (xlsx)"
+                "excel": "Microsoft Excel format (xlsx)"
             },
             "LineupPanelActions": {
                 "rankingPanelTabTitle": "Ranking Configuration",
@@ -199,7 +199,7 @@
                 "toggleOverview": "En/Disable Overview",
                 "downloadData": "Download Data",
                 "downloadAll": "Download All",
-                "excel": "Save in Microsoft Excel format (xlsx)",
+                "excel": "Microsoft Excel format (xlsx)",
                 "downloadSelectedRows": "Download Selected Rows Only",
                 "customize": "Customize&hellip;",
                 "saveEntities": "Save List of Entities",

--- a/dist/locales/en/tdp.json
+++ b/dist/locales/en/tdp.json
@@ -206,7 +206,7 @@
                 "databaseColumns": "Database Columns",
                 "parameterizedScores": "Parameterized Scores",
                 "previouslyAddedColumns": "Previously Added Columns",
-                "combiningColumns": "Combining Columns",
+                "combiningColumns": "Combined Columns",
                 "weightedSum": "Weighted Sum",
                 "scriptedCombination": "Scripted Combination",
                 "nested": "Nested",

--- a/dist/locales/en/tdp.json
+++ b/dist/locales/en/tdp.json
@@ -187,7 +187,7 @@
                 "tsv": "TSV (tab separated)",
                 "csvColon": "CSV (semicolon separated)",
                 "json": "JSON",
-                "excel": "Microsoft Excel (xlsx)"
+                "excel": "Save in Microsoft Excel format (xlsx)"
             },
             "LineupPanelActions": {
                 "rankingPanelTabTitle": "Ranking Configuration",
@@ -199,7 +199,7 @@
                 "toggleOverview": "En/Disable Overview",
                 "downloadData": "Download Data",
                 "downloadAll": "Download All",
-                "excel": "Microsoft Excel (xlsx)",
+                "excel": "Save in Microsoft Excel format (xlsx)",
                 "downloadSelectedRows": "Download Selected Rows Only",
                 "customize": "Customize&hellip;",
                 "saveEntities": "Save List of Entities",

--- a/src/locales/en/tdp.json
+++ b/src/locales/en/tdp.json
@@ -203,7 +203,7 @@
         "tsv": "TSV (tab separated)",
         "csvColon": "CSV (semicolon separated)",
         "json": "JSON",
-        "excel": "Save in Microsoft Excel format (xlsx)"
+        "excel": "Microsoft Excel format (xlsx)"
       },
 
       "LineupPanelActions": {
@@ -216,7 +216,7 @@
         "toggleOverview": "En/Disable Overview",
         "downloadData": "Download Data",
         "downloadAll": "Download All",
-        "excel": "Save in Microsoft Excel format (xlsx)",
+        "excel": "Microsoft Excel format (xlsx)",
         "downloadSelectedRows": "Download Selected Rows Only",
         "customize": "Customize&hellip;",
         "saveEntities": "Save List of Entities",

--- a/src/locales/en/tdp.json
+++ b/src/locales/en/tdp.json
@@ -223,7 +223,7 @@
         "databaseColumns": "Database Columns",
         "parameterizedScores": "Parameterized Scores",
         "previouslyAddedColumns": "Previously Added Columns",
-        "combiningColumns": "Combining Columns",
+        "combiningColumns": "Combined Columns",
         "weightedSum": "Weighted Sum",
         "scriptedCombination": "Scripted Combination",
         "nested": "Nested",

--- a/src/locales/en/tdp.json
+++ b/src/locales/en/tdp.json
@@ -203,7 +203,7 @@
         "tsv": "TSV (tab separated)",
         "csvColon": "CSV (semicolon separated)",
         "json": "JSON",
-        "excel": "Microsoft Excel (xlsx)"
+        "excel": "Save in Microsoft Excel format (xlsx)"
       },
 
       "LineupPanelActions": {
@@ -216,7 +216,7 @@
         "toggleOverview": "En/Disable Overview",
         "downloadData": "Download Data",
         "downloadAll": "Download All",
-        "excel": "Microsoft Excel (xlsx)",
+        "excel": "Save in Microsoft Excel format (xlsx)",
         "downloadSelectedRows": "Download Selected Rows Only",
         "customize": "Customize&hellip;",
         "saveEntities": "Save List of Entities",


### PR DESCRIPTION
Part of Caleydo/tdp_bi_bioinfodb#1138

### Summary 
Fixes the below issues

- [x] UX: Wording _Microsoft Excel (xlsx)_ vs. _Save in Microsoft Excel format (xlsx)_; might be confusing since some user have LibreOffice, etc.

- [x] UX: Wording _Combining Columns_ (current) vs. _Combined Columns_