### PR TITLE
Hide `.lu-resize-helper` to fix ranking scrolling

### DIFF
--- a/dist/scss/_view_lineup.scss
+++ b/dist/scss/_view_lineup.scss
@@ -72,7 +72,7 @@
     padding-bottom: 1px; // no idea otherwise scrollbar
   }
 
-  footer {
+  footer:not(.lu-resize-helper) {
     display: block !important;
   }
 }

--- a/src/scss/_view_lineup.scss
+++ b/src/scss/_view_lineup.scss
@@ -72,7 +72,7 @@
     padding-bottom: 1px; // no idea otherwise scrollbar
   }
 
-  footer {
+  footer:not(.lu-resize-helper) {
     display: block !important;
   }
 }


### PR DESCRIPTION
Fixes #442

### Summary

The following style forced the ranking footer to be visible:

```scss
.lineup-engine {
  // ...

  footer {
    display: block !important;
  }
```

However, there are two footers:

![grafik](https://user-images.githubusercontent.com/5851088/99500257-5f817280-297a-11eb-9eea-2b0cf74642a6.png)

The LineUp library hides the `.lu-resize-helper` by default, but with the style above we force it show, which changes the behavior to the one described in #442.

This fix hides the `.lu-resize-helper` resulting in the correct behavior:

![ordino-filter](https://user-images.githubusercontent.com/5851088/99503526-9a85a500-297e-11eb-9ccb-e1e660a45c29.gif)



