### PR TITLE
Remove default SVG style

### DIFF
--- a/dist/scss/_view.scss
+++ b/dist/scss/_view.scss
@@ -2,18 +2,6 @@
 @import '~font-awesome/scss/variables';
 @import '~font-awesome/scss/mixins';
 
-svg {
-  // generic axes styles
-  path,
-  .axis path,
-  line,
-  .axis line {
-    fill: none;
-    stroke-width: 1;
-    stroke: black;
-    shape-rendering: crispEdges;
-  }
-}
 
 .#{$tdp-css-prefix}-view {
   &.multiple {

--- a/src/scss/_view.scss
+++ b/src/scss/_view.scss
@@ -2,18 +2,6 @@
 @import '~font-awesome/scss/variables';
 @import '~font-awesome/scss/mixins';
 
-svg {
-  // generic axes styles
-  path,
-  .axis path,
-  line,
-  .axis line {
-    fill: none;
-    stroke-width: 1;
-    stroke: black;
-    shape-rendering: crispEdges;
-  }
-}
 
 .#{$tdp-css-prefix}-view {
   &.multiple {


### PR DESCRIPTION
Because it doesn't make sense to define such a default styling for svgs, we should remove that