### PR TITLE
Switch to `lineupjs@next` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "d3": "~3.5.17",
     "jquery": "~3.5.1",
-    "lineupjs": "github:lineupjs/lineupjs#develop",
+    "lineupjs": "next",
     "phovea_clue": "github:phovea/phovea_clue#develop",
     "select2": "~4.0.13",
     "select2-bootstrap-theme": "0.1.0-beta.9",


### PR DESCRIPTION
Fixes https://github.com/lineupjs/lineupjs/issues/422

Instead of building lineupjs from develop branch we are using the build files from the npm registry under the `next` tag.