### PR TITLE
Add `preview()` function to tour extension point

### DIFF
--- a/src/tour/extensions.ts
+++ b/src/tour/extensions.ts
@@ -21,6 +21,13 @@ export interface ITDPTourExtensionDesc {
   description?: string;
 
   /**
+   * An optional preview callback function returning a URL promise
+   * The preview image should have 320x180 px
+   * @returns {Promise<string>}
+   */
+   preview?: () => Promise<string>;
+
+  /**
    * Set a level for the tour.
    * Note: Manual tours are only triggered on demand via event.
    */
@@ -128,4 +135,3 @@ export interface IViewTourContext {
   instance: IView | null;
   selection: ISelection;
 }
-

--- a/src/tour/extensions.ts
+++ b/src/tour/extensions.ts
@@ -22,7 +22,7 @@ export interface ITDPTourExtensionDesc {
 
   /**
    * An optional preview callback function returning a URL promise
-   * The preview image should have 320x180 px
+   * The preview image should have 350x200 px
    * @returns {Promise<string>}
    */
    preview?: () => Promise<string>;


### PR DESCRIPTION
### Summary
* Add an optional `preview()` function to tour extension point
* The interface is similar to [`IViewPluginDesc.preview()`](https://github.com/datavisyn/tdp_core/blob/4870179ed2dd4d55717f088760f7bb34b6675714/src/base/interfaces.ts#L311-L315)