### PR TITLE
Changed tdp-tooltip z-index to 1500 to show it above modal

### DIFF
--- a/dist/scss/components/_tooltip.scss
+++ b/dist/scss/components/_tooltip.scss
@@ -5,7 +5,7 @@
   border-radius: 5px;
   border: 1px solid black;
   padding: 5px;
-  z-index: 1000;
+  z-index: 1500;
 
   [x-arrow] {
     width: 0;

--- a/src/scss/components/_tooltip.scss
+++ b/src/scss/components/_tooltip.scss
@@ -5,7 +5,7 @@
   border-radius: 5px;
   border: 1px solid black;
   padding: 5px;
-  z-index: 1000;
+  z-index: 1500;
 
   [x-arrow] {
     width: 0;


### PR DESCRIPTION
Using the tdp-tooltip in a modal does show the tooltip behind the modal, because the modal has a z-index of 1300. Here, we move the tooltip "above" the bootstrap modal.  