### PR TITLE
Increase LineUp font size and improve styles

### DIFF
--- a/dist/scss/components/_view_lineup.scss
+++ b/dist/scss/components/_view_lineup.scss
@@ -428,7 +428,7 @@ $lu_assets: '~lineupjs/src/assets';
 
         &.once .lu-search {
           position: absolute;
-          top: 1.8em;
+          top: 2em;
           width: 17.5em;
           left: -15em;
           z-index: 2;

--- a/dist/scss/vendors/_lineup.scss
+++ b/dist/scss/vendors/_lineup.scss
@@ -1,2 +1,173 @@
+// TODO override the following SCSS variables once SCSS import is working again
+$lu_dialog_font_size: 1rem !default;
+$lu_toolbar_font_size: 1rem !default;
+
 // use css because importing sass file from src requires font awesome v4 dependency
 @import '~lineupjs/build/LineUpJS.css';
+
+// override the font-size manually (since the SCSS variables above does not work)
+.lu-tooltip,
+.lu-dialog {
+  font-size: $lu_dialog_font_size;
+
+  // adapt LineUp dialogs to Bootstrap v4 dialog style
+  padding: 1rem 1rem 0.5rem;
+  gap: 10px;
+  background-clip: padding-box;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 0.3rem;
+
+  strong {
+    margin: unset;
+  }
+}
+
+.lu-dialog {
+  input {
+    font-size: inherit;
+  }
+
+  .lu-checkbox:not(.lu-dialog-filter-table-entry) > span {
+    font-size: inherit;
+    margin: unset;
+  }
+
+  strong:not(:first-of-type) {
+    margin-top: 1rem;
+  }
+}
+
+.lu-dialog-buttons {
+  margin-top: 0.5rem;
+}
+
+.lu-dialog-button {
+  margin: unset;
+}
+
+.lu-hierarchy-entry,
+.lu-hierarchy-adder,
+.lu-toolbar,
+.lu-more-options,
+.lu-side-panel-rankings > i,
+.lu-side-panel-ranking-label > i {
+  font-size: $lu_toolbar_font_size;
+}
+
+.lu-summary {
+  font-size: inherit;
+
+  .lu-checkbox > span {
+    font-size: inherit;
+    margin: unset;
+  }
+}
+
+.lu-stats {
+  font-size: inherit;
+
+  & > span {
+    font-size: inherit;
+  }
+}
+
+.lu-side-panel-summary {
+  font-size: inherit;
+
+  &.lu-renderer-string {
+    gap: 10px;
+  }
+}
+
+.lu-side-panel-ranking::before,
+.lu-group-hierarchy::before,
+.lu-sort-hierarchy::before,
+.lu-sort-groups-hierarchy::before {
+  font-size: inherit;
+}
+
+.lu-side-panel-entry-header {
+  font-size: inherit;
+}
+
+.lu-dialog {
+  .lu-checkbox {
+    display: flex;
+    align-items: baseline;
+    gap: 5px;
+  }
+}
+
+.lu-dialog.lu-more-options {
+  padding: 0;
+  gap: 0;
+
+  & > i.lu-action {
+    padding: 10px;
+    gap: 5px;
+  }
+}
+
+.lu-search::before {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.lu-hierarchy .lu-hierarchy-adder .lu-search::before {
+  height: unset;
+}
+
+.lu-search-input {
+  height: unset;
+}
+
+.lu-search-list {
+  top: 1.85rem;
+
+  li.lu-search-item > span,
+  li.lu-search-group > span {
+    padding: 0.5rem;
+  }
+}
+
+.lu-search-open > input {
+  border-radius: 0 4px 0 0;
+}
+
+.lu-hierarchy-entry,
+.lu-hierarchy-adder {
+  padding: 0.5rem 0.5rem 0.5rem 0.5rem;
+  align-items: baseline;
+  gap: 5px;
+}
+
+.lu-hierarchy-adder > .lu-search > input {
+  height: 1.8rem;
+  font-size: inherit;
+}
+
+span.lu-mapping-hint {
+  font-size: small;
+}
+
+.lu-histogram-min-hint,
+.lu-histogram-max-hint {
+  font-size: inherit;
+}
+
+.lu-histogram-max,
+.lu-histogram-min {
+  &::before {
+    bottom: -1.2rem;
+    font-size: small;
+  }
+}
+
+.lu-histogram .lu-checkbox {
+  bottom: -3rem;
+}
+
+.lu-dialog-rename {
+  width: 20rem;
+}

--- a/dist/scss/vendors/_lineup.scss
+++ b/dist/scss/vendors/_lineup.scss
@@ -92,20 +92,11 @@ $lu_toolbar_font_size: 1rem !default;
 }
 
 .lu-side-panel-entry {
-  border-top: 1px solid #999999;
   padding: 0 0 1rem;
-
-  &:hover,
-  &:focus-within {
-    .lu-side-panel-entry-header {
-      background-color: #f3f3f3;
-    }
-  }
 }
 
 .lu-side-panel-entry-header {
   font-size: inherit;
-  background: unset;
   border-top: unset;
   padding: 0.5rem;
   transition: background-color 0.3s ease;

--- a/dist/scss/vendors/_lineup.scss
+++ b/dist/scss/vendors/_lineup.scss
@@ -73,6 +73,7 @@ $lu_toolbar_font_size: 1rem !default;
 
 .lu-side-panel-summary {
   font-size: inherit;
+  margin: 0.5rem;
 
   &.lu-renderer-string {
     gap: 10px;
@@ -90,8 +91,28 @@ $lu_toolbar_font_size: 1rem !default;
   }
 }
 
+.lu-side-panel-entry {
+  border-top: 1px solid #999999;
+  padding: 0 0 1rem;
+
+  &:hover,
+  &:focus-within {
+    .lu-side-panel-entry-header {
+      background-color: #f3f3f3;
+    }
+  }
+}
+
 .lu-side-panel-entry-header {
   font-size: inherit;
+  background: unset;
+  border-top: unset;
+  padding: 0.5rem;
+  transition: background-color 0.3s ease;
+}
+
+.lu-side-panel-labels {
+  padding: 0;
 }
 
 .lu-dialog {

--- a/dist/scss/vendors/_lineup.scss
+++ b/dist/scss/vendors/_lineup.scss
@@ -79,11 +79,15 @@ $lu_toolbar_font_size: 1rem !default;
   }
 }
 
-.lu-side-panel-ranking::before,
-.lu-group-hierarchy::before,
-.lu-sort-hierarchy::before,
-.lu-sort-groups-hierarchy::before {
-  font-size: inherit;
+.lu-side-panel-ranking,
+.lu-group-hierarchy,
+.lu-sort-hierarchy,
+.lu-sort-groups-hierarchy {
+  margin-bottom: 1rem;
+
+  &::before {
+    font-size: inherit;
+  }
 }
 
 .lu-side-panel-entry-header {
@@ -95,6 +99,7 @@ $lu_toolbar_font_size: 1rem !default;
     display: flex;
     align-items: baseline;
     gap: 5px;
+    margin: unset;
   }
 }
 
@@ -112,6 +117,7 @@ $lu_toolbar_font_size: 1rem !default;
   display: flex;
   justify-content: center;
   align-items: center;
+  border-color: #ced4da;
 }
 
 .lu-hierarchy .lu-hierarchy-adder .lu-search::before {
@@ -120,6 +126,7 @@ $lu_toolbar_font_size: 1rem !default;
 
 .lu-search-input {
   height: unset;
+  border-color: #ced4da;
 }
 
 .lu-search-list {
@@ -137,9 +144,10 @@ $lu_toolbar_font_size: 1rem !default;
 
 .lu-hierarchy-entry,
 .lu-hierarchy-adder {
-  padding: 0.5rem 0.5rem 0.5rem 0.5rem;
+  padding: 0.3rem 0.5rem;
   align-items: baseline;
   gap: 5px;
+  border-top: none;
 }
 
 .lu-hierarchy-adder > .lu-search > input {

--- a/dist/scss/vendors/_lineup.scss
+++ b/dist/scss/vendors/_lineup.scss
@@ -104,12 +104,17 @@ $lu_toolbar_font_size: 1rem !default;
 }
 
 .lu-dialog.lu-more-options {
-  padding: 0;
+  padding: 0.5rem 0;
   gap: 0;
 
   & > i.lu-action {
-    padding: 10px;
-    gap: 5px;
+    align-items: baseline;
+    padding: 0.25rem 1.5rem 0.25rem 0.75rem;
+    gap: 0.5rem;
+
+    & > span {
+      margin: unset;
+    }
   }
 }
 

--- a/src/scss/components/_view_lineup.scss
+++ b/src/scss/components/_view_lineup.scss
@@ -428,7 +428,7 @@ $lu_assets: '~lineupjs/src/assets';
 
         &.once .lu-search {
           position: absolute;
-          top: 1.8em;
+          top: 2em;
           width: 17.5em;
           left: -15em;
           z-index: 2;

--- a/src/scss/vendors/_lineup.scss
+++ b/src/scss/vendors/_lineup.scss
@@ -1,2 +1,173 @@
+// TODO override the following SCSS variables once SCSS import is working again
+$lu_dialog_font_size: 1rem !default;
+$lu_toolbar_font_size: 1rem !default;
+
 // use css because importing sass file from src requires font awesome v4 dependency
 @import '~lineupjs/build/LineUpJS.css';
+
+// override the font-size manually (since the SCSS variables above does not work)
+.lu-tooltip,
+.lu-dialog {
+  font-size: $lu_dialog_font_size;
+
+  // adapt LineUp dialogs to Bootstrap v4 dialog style
+  padding: 1rem 1rem 0.5rem;
+  gap: 10px;
+  background-clip: padding-box;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 0.3rem;
+
+  strong {
+    margin: unset;
+  }
+}
+
+.lu-dialog {
+  input {
+    font-size: inherit;
+  }
+
+  .lu-checkbox:not(.lu-dialog-filter-table-entry) > span {
+    font-size: inherit;
+    margin: unset;
+  }
+
+  strong:not(:first-of-type) {
+    margin-top: 1rem;
+  }
+}
+
+.lu-dialog-buttons {
+  margin-top: 0.5rem;
+}
+
+.lu-dialog-button {
+  margin: unset;
+}
+
+.lu-hierarchy-entry,
+.lu-hierarchy-adder,
+.lu-toolbar,
+.lu-more-options,
+.lu-side-panel-rankings > i,
+.lu-side-panel-ranking-label > i {
+  font-size: $lu_toolbar_font_size;
+}
+
+.lu-summary {
+  font-size: inherit;
+
+  .lu-checkbox > span {
+    font-size: inherit;
+    margin: unset;
+  }
+}
+
+.lu-stats {
+  font-size: inherit;
+
+  & > span {
+    font-size: inherit;
+  }
+}
+
+.lu-side-panel-summary {
+  font-size: inherit;
+
+  &.lu-renderer-string {
+    gap: 10px;
+  }
+}
+
+.lu-side-panel-ranking::before,
+.lu-group-hierarchy::before,
+.lu-sort-hierarchy::before,
+.lu-sort-groups-hierarchy::before {
+  font-size: inherit;
+}
+
+.lu-side-panel-entry-header {
+  font-size: inherit;
+}
+
+.lu-dialog {
+  .lu-checkbox {
+    display: flex;
+    align-items: baseline;
+    gap: 5px;
+  }
+}
+
+.lu-dialog.lu-more-options {
+  padding: 0;
+  gap: 0;
+
+  & > i.lu-action {
+    padding: 10px;
+    gap: 5px;
+  }
+}
+
+.lu-search::before {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.lu-hierarchy .lu-hierarchy-adder .lu-search::before {
+  height: unset;
+}
+
+.lu-search-input {
+  height: unset;
+}
+
+.lu-search-list {
+  top: 1.85rem;
+
+  li.lu-search-item > span,
+  li.lu-search-group > span {
+    padding: 0.5rem;
+  }
+}
+
+.lu-search-open > input {
+  border-radius: 0 4px 0 0;
+}
+
+.lu-hierarchy-entry,
+.lu-hierarchy-adder {
+  padding: 0.5rem 0.5rem 0.5rem 0.5rem;
+  align-items: baseline;
+  gap: 5px;
+}
+
+.lu-hierarchy-adder > .lu-search > input {
+  height: 1.8rem;
+  font-size: inherit;
+}
+
+span.lu-mapping-hint {
+  font-size: small;
+}
+
+.lu-histogram-min-hint,
+.lu-histogram-max-hint {
+  font-size: inherit;
+}
+
+.lu-histogram-max,
+.lu-histogram-min {
+  &::before {
+    bottom: -1.2rem;
+    font-size: small;
+  }
+}
+
+.lu-histogram .lu-checkbox {
+  bottom: -3rem;
+}
+
+.lu-dialog-rename {
+  width: 20rem;
+}

--- a/src/scss/vendors/_lineup.scss
+++ b/src/scss/vendors/_lineup.scss
@@ -92,20 +92,11 @@ $lu_toolbar_font_size: 1rem !default;
 }
 
 .lu-side-panel-entry {
-  border-top: 1px solid #999999;
   padding: 0 0 1rem;
-
-  &:hover,
-  &:focus-within {
-    .lu-side-panel-entry-header {
-      background-color: #f3f3f3;
-    }
-  }
 }
 
 .lu-side-panel-entry-header {
   font-size: inherit;
-  background: unset;
   border-top: unset;
   padding: 0.5rem;
   transition: background-color 0.3s ease;

--- a/src/scss/vendors/_lineup.scss
+++ b/src/scss/vendors/_lineup.scss
@@ -73,6 +73,7 @@ $lu_toolbar_font_size: 1rem !default;
 
 .lu-side-panel-summary {
   font-size: inherit;
+  margin: 0.5rem;
 
   &.lu-renderer-string {
     gap: 10px;
@@ -90,8 +91,28 @@ $lu_toolbar_font_size: 1rem !default;
   }
 }
 
+.lu-side-panel-entry {
+  border-top: 1px solid #999999;
+  padding: 0 0 1rem;
+
+  &:hover,
+  &:focus-within {
+    .lu-side-panel-entry-header {
+      background-color: #f3f3f3;
+    }
+  }
+}
+
 .lu-side-panel-entry-header {
   font-size: inherit;
+  background: unset;
+  border-top: unset;
+  padding: 0.5rem;
+  transition: background-color 0.3s ease;
+}
+
+.lu-side-panel-labels {
+  padding: 0;
 }
 
 .lu-dialog {

--- a/src/scss/vendors/_lineup.scss
+++ b/src/scss/vendors/_lineup.scss
@@ -79,11 +79,15 @@ $lu_toolbar_font_size: 1rem !default;
   }
 }
 
-.lu-side-panel-ranking::before,
-.lu-group-hierarchy::before,
-.lu-sort-hierarchy::before,
-.lu-sort-groups-hierarchy::before {
-  font-size: inherit;
+.lu-side-panel-ranking,
+.lu-group-hierarchy,
+.lu-sort-hierarchy,
+.lu-sort-groups-hierarchy {
+  margin-bottom: 1rem;
+
+  &::before {
+    font-size: inherit;
+  }
 }
 
 .lu-side-panel-entry-header {
@@ -95,6 +99,7 @@ $lu_toolbar_font_size: 1rem !default;
     display: flex;
     align-items: baseline;
     gap: 5px;
+    margin: unset;
   }
 }
 
@@ -112,6 +117,7 @@ $lu_toolbar_font_size: 1rem !default;
   display: flex;
   justify-content: center;
   align-items: center;
+  border-color: #ced4da;
 }
 
 .lu-hierarchy .lu-hierarchy-adder .lu-search::before {
@@ -120,6 +126,7 @@ $lu_toolbar_font_size: 1rem !default;
 
 .lu-search-input {
   height: unset;
+  border-color: #ced4da;
 }
 
 .lu-search-list {
@@ -137,9 +144,10 @@ $lu_toolbar_font_size: 1rem !default;
 
 .lu-hierarchy-entry,
 .lu-hierarchy-adder {
-  padding: 0.5rem 0.5rem 0.5rem 0.5rem;
+  padding: 0.3rem 0.5rem;
   align-items: baseline;
   gap: 5px;
+  border-top: none;
 }
 
 .lu-hierarchy-adder > .lu-search > input {

--- a/src/scss/vendors/_lineup.scss
+++ b/src/scss/vendors/_lineup.scss
@@ -104,12 +104,17 @@ $lu_toolbar_font_size: 1rem !default;
 }
 
 .lu-dialog.lu-more-options {
-  padding: 0;
+  padding: 0.5rem 0;
   gap: 0;
 
   & > i.lu-action {
-    padding: 10px;
-    gap: 5px;
+    align-items: baseline;
+    padding: 0.25rem 1.5rem 0.25rem 0.75rem;
+    gap: 0.5rem;
+
+    & > span {
+      margin: unset;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #503

### Summary

* Increase overall font size
* Increase overall margin and paddings
* Make LineUp dialogs look like Bootstrap 4 dialogs
* Refresh side panel style
* Increase width of rename dialog

### Screenshots

**Before**

![ordino-daily caleydoapp org_](https://user-images.githubusercontent.com/5851088/116813046-1f8e0080-ab52-11eb-9bcd-c9e4e2037531.png)


**Now**

![localhost_8080_app_ (4)](https://user-images.githubusercontent.com/5851088/116827001-3440b780-ab97-11eb-8bbb-a4b34b496811.png)


![grafik](https://user-images.githubusercontent.com/5851088/116813067-43e9dd00-ab52-11eb-9ff9-77d67c4d289d.png)

![grafik](https://user-images.githubusercontent.com/5851088/116813074-519f6280-ab52-11eb-9426-d80b164abe85.png)

![grafik](https://user-images.githubusercontent.com/5851088/116813146-a6db7400-ab52-11eb-83ba-12fde08e0e80.png)

