### PR TITLE
Remove `react-bootstrap` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "react-plotly.js": "^2.4.0",
     "react-split": "^2.0.9",
     "bootstrap": "^4.5.3",
-    "react-bootstrap": "^1.4.0",
     "plotly.js-dist": "^1.57.1"
   },
   "devDependencies": {
@@ -104,7 +103,6 @@
     "@types/react-plotly.js": "^2.2.4",
     "@types/react": "^16.9.23",
     "@types/react-dom": "^16.9.5",
-    "@types/react-bootstrap": "^0.32.24",
     "identity-obj-proxy": "~3.0.0",
     "jest": "~26.6.3",
     "jest-raw-loader": "~1.0.1",


### PR DESCRIPTION
We will use plain Bootstrap as agreed in the core meeting.