### PR TITLE
Fix locale string in TDPApplicationUtils

### DIFF
--- a/dist/utils/TDPApplicationUtils.d.ts
+++ b/dist/utils/TDPApplicationUtils.d.ts
@@ -40,8 +40,10 @@ export declare class TDPApplicationUtils {
         inverse: import("phovea_core").IAction;
     };
     static initSession(map: object): import("phovea_core").IAction;
-    static setParameterImpl(inputs: IObjectRef<any>[], parameter: any, graph: ProvenanceGraph): any;
-    static setParameter(view: IObjectRef<IParameterAble>, name: string, value: any, previousValue: any): any;
+    static setParameterImpl(inputs: IObjectRef<any>[], parameter: any, graph: ProvenanceGraph): Promise<{
+        inverse: import("phovea_core").IAction;
+    }>;
+    static setParameter(view: IObjectRef<IParameterAble>, name: string, value: any, previousValue: any): import("phovea_core").IAction;
     static compressSetParameter(path: ActionNode[]): ActionNode[];
     /**
      * @deprecated

--- a/dist/utils/TDPApplicationUtils.js
+++ b/dist/utils/TDPApplicationUtils.js
@@ -266,7 +266,7 @@ TDPApplicationUtils.getAreas = () => {
         [25 * TDPApplicationUtils.DAY, (d) => I18nextManager.getInstance().i18n.t('tdp:core.utilsInternal.day', { count: Math.ceil(d / TDPApplicationUtils.DAY) })],
         [45 * TDPApplicationUtils.DAY, I18nextManager.getInstance().i18n.t('tdp:core.utilsInternal.month')],
         [319 * TDPApplicationUtils.DAY, (d) => I18nextManager.getInstance().i18n.t('tdp:core.utilsInternal.month', { count: Math.ceil(d / TDPApplicationUtils.DAY / 30) })],
-        [547 * TDPApplicationUtils.DAY, (d) => I18nextManager.getInstance().i18n.t('tdp:core.utilsInternal.hour')]
+        [547 * TDPApplicationUtils.DAY, (d) => I18nextManager.getInstance().i18n.t('tdp:core.utilsInternal.year')]
     ];
 };
 //# sourceMappingURL=TDPApplicationUtils.js.map

--- a/src/utils/TDPApplicationUtils.ts
+++ b/src/utils/TDPApplicationUtils.ts
@@ -39,7 +39,7 @@ export class TDPApplicationUtils {
       [25 * TDPApplicationUtils.DAY, (d) => I18nextManager.getInstance().i18n.t('tdp:core.utilsInternal.day', {count: Math.ceil(d / TDPApplicationUtils.DAY)})],
       [45 * TDPApplicationUtils.DAY, I18nextManager.getInstance().i18n.t('tdp:core.utilsInternal.month')],
       [319 * TDPApplicationUtils.DAY, (d) => I18nextManager.getInstance().i18n.t('tdp:core.utilsInternal.month', {count: Math.ceil(d / TDPApplicationUtils.DAY / 30)})],
-      [547 * TDPApplicationUtils.DAY, (d) => I18nextManager.getInstance().i18n.t('tdp:core.utilsInternal.hour')]
+      [547 * TDPApplicationUtils.DAY, (d) => I18nextManager.getInstance().i18n.t('tdp:core.utilsInternal.year')]
     ];
   }
 


### PR DESCRIPTION
COming from Caleydo/tdp_bi_bioinfodb#1291

### Summary
* Switched the locale strings to say `a year ago `when the relative date is > year 
It was wrongly set to `an hour ago` 