### PR TITLE
Move docutils pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ flask-swagger-ui==3.36.0
 yamlreader==3.0.4
 alembic==1.4.3
 openpyxl~=3.0.5
--e git+https://github.com/phovea/phovea_server.git@develop#egg=phovea_server
+-e git+https://github.com/phovea/phovea_server.git@vstoiber/move_docutils_pin#egg=phovea_server

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ flask-swagger-ui==3.36.0
 yamlreader==3.0.4
 alembic==1.4.3
 openpyxl~=3.0.5
--e git+https://github.com/phovea/phovea_server.git@vstoiber/move_docutils_pin#egg=phovea_server
+-e git+https://github.com/phovea/phovea_server.git@develop#egg=phovea_server

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,3 @@ yamlreader==3.0.4
 alembic==1.4.3
 openpyxl~=3.0.5
 -e git+https://github.com/phovea/phovea_server.git@develop#egg=phovea_server
-# Pin docutils to avoid AttributeError: 'Values' object has no attribute 'section_self_link'
-docutils==0.17.1


### PR DESCRIPTION
### Summary
* Move docutils pin from `tdp_core` to `phovea_server`