### PR TITLE
Added preserves_order flag to SQL mapping table

### DIFF
--- a/tdp_core/mapping_table.py
+++ b/tdp_core/mapping_table.py
@@ -1,4 +1,5 @@
 import logging
+from .dbview import DBMapping
 from . import db
 import itertools
 
@@ -6,12 +7,14 @@ _log = logging.getLogger(__name__)
 
 
 class SQLMappingTable(object):
-  def __init__(self, mapping, engine):
+  def __init__(self, mapping: DBMapping, engine):
     self.from_idtype = mapping.from_idtype
     self.to_idtype = mapping.to_idtype
     self._engine = engine
     self._query = mapping.query
     self._integer_ids = mapping.integer_ids
+    # Enable batch mapping operations by ensuring the correct return order
+    self.preserves_order = True
 
   def __call__(self, ids):
     # ensure strings
@@ -25,6 +28,7 @@ class SQLMappingTable(object):
       # handle multi mappings
       data = sorted(mapped, key=lambda x: x['f'])
       grouped = {k: [r['t'] for r in g] for k, g in itertools.groupby(data, lambda x: x['f'])}
+      # Return according to the given ids to ensure that we are preserving the order correctly
       return [grouped.get(id, []) for id in ids]
 
 


### PR DESCRIPTION
A long time ago, the `preserves_mapping` attribute was added as performance improvement to enable bulk-id-mappings. Bulk-id-mappings was disabled before as some mappers could not guarantee that the order of incoming ids == order of outgoing ids. Read more about it here: https://github.com/phovea/phovea_server/pull/141

This PR sets this flag in the sql-mapping table, as this mapper guarantees a preserved order. 
The performance increase is **huge** when testing with many items, as previously a query was sent to the database for **every single id**. As a test with human genes, ~60k queries were sent... Now, a single query with a large where is sent instead.

I added a comment to the line which ensures a preserved order. 