### PR TITLE
remove white-spaces when injecting css variables in root

### DIFF
--- a/dist/scss/abstracts/_ui_colors.scss
+++ b/dist/scss/abstracts/_ui_colors.scss
@@ -9,6 +9,6 @@ $visyn-selection-colors: (
 // create css variables and inject them in :root
 :root {
   @each $key, $value in map-collect($visyn-selection-colors) {
-    --visyn-#{$key}: #{$value};
+    --visyn-#{$key}:#{$value};
   }
 }

--- a/dist/scss/abstracts/_ui_colors.scss
+++ b/dist/scss/abstracts/_ui_colors.scss
@@ -9,6 +9,7 @@ $visyn-selection-colors: (
 // create css variables and inject them in :root
 :root {
   @each $key, $value in map-collect($visyn-selection-colors) {
+    // injecting without white-space as the value will be read with a leading white-space otherwise
     --visyn-#{$key}:#{$value};
   }
 }

--- a/dist/scss/abstracts/_vis_colors.scss
+++ b/dist/scss/abstracts/_vis_colors.scss
@@ -3,7 +3,7 @@
 // categorical color map
 $visyn-categorical-colors: (
   'c1': '#337AB7',
-  'c2': '#ec6836',
+  'c2':'#ec6836',
   'c3': '#75c4c2',
   'c4': '#e9d36c',
   'c5': '#24b466',
@@ -147,6 +147,6 @@ $visyn-diverging-colors-blue-pink: (
     $visyn-diverging-colors-blue-yellow,
     $visyn-diverging-colors-blue-pink)
   {
-    --visyn-#{$key}: #{$value};
+    --visyn-#{$key}:#{$value};
   }
 }

--- a/dist/scss/abstracts/_vis_colors.scss
+++ b/dist/scss/abstracts/_vis_colors.scss
@@ -3,7 +3,7 @@
 // categorical color map
 $visyn-categorical-colors: (
   'c1': '#337AB7',
-  'c2':'#ec6836',
+  'c2': '#ec6836',
   'c3': '#75c4c2',
   'c4': '#e9d36c',
   'c5': '#24b466',
@@ -147,6 +147,7 @@ $visyn-diverging-colors-blue-pink: (
     $visyn-diverging-colors-blue-yellow,
     $visyn-diverging-colors-blue-pink)
   {
+    // injecting without white-space as the value will be read with a leading white-space otherwise
     --visyn-#{$key}:#{$value};
   }
 }

--- a/dist/utils/getCssValue.js
+++ b/dist/utils/getCssValue.js
@@ -4,6 +4,6 @@
  * @returns the value which is stored in the css variable or undefined if the variable could not be found
  */
 export function getCssValue(name) {
-    return getComputedStyle(document.documentElement).getPropertyValue(`--${name}`);
+    return getComputedStyle(document.documentElement).getPropertyValue(`--${name}`).trim();
 }
 //# sourceMappingURL=getCssValue.js.map

--- a/dist/utils/getCssValue.js.map
+++ b/dist/utils/getCssValue.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"getCssValue.js","sourceRoot":"","sources":["../../src/utils/getCssValue.ts"],"names":[],"mappings":"AAAA;;;;GAIG;AACH,MAAM,UAAU,WAAW,CAAC,IAAY;IACtC,OAAO,gBAAgB,CAAC,QAAQ,CAAC,eAAe,CAAC,CAAC,gBAAgB,CAAC,KAAK,IAAI,EAAE,CAAC,CAAC;AAClF,CAAC"}
+{"version":3,"file":"getCssValue.js","sourceRoot":"","sources":["../../src/utils/getCssValue.ts"],"names":[],"mappings":"AAAA;;;;GAIG;AACH,MAAM,UAAU,WAAW,CAAC,IAAY;IACtC,OAAO,gBAAgB,CAAC,QAAQ,CAAC,eAAe,CAAC,CAAC,gBAAgB,CAAC,KAAK,IAAI,EAAE,CAAC,CAAC,IAAI,EAAE,CAAC;AACzF,CAAC"}

--- a/src/scss/abstracts/_ui_colors.scss
+++ b/src/scss/abstracts/_ui_colors.scss
@@ -9,6 +9,6 @@ $visyn-selection-colors: (
 // create css variables and inject them in :root
 :root {
   @each $key, $value in map-collect($visyn-selection-colors) {
-    --visyn-#{$key}: #{$value};
+    --visyn-#{$key}:#{$value};
   }
 }

--- a/src/scss/abstracts/_ui_colors.scss
+++ b/src/scss/abstracts/_ui_colors.scss
@@ -9,6 +9,7 @@ $visyn-selection-colors: (
 // create css variables and inject them in :root
 :root {
   @each $key, $value in map-collect($visyn-selection-colors) {
+    // injecting without white-space as the value will be read with a leading white-space otherwise
     --visyn-#{$key}:#{$value};
   }
 }

--- a/src/scss/abstracts/_vis_colors.scss
+++ b/src/scss/abstracts/_vis_colors.scss
@@ -147,6 +147,6 @@ $visyn-diverging-colors-blue-pink: (
     $visyn-diverging-colors-blue-yellow,
     $visyn-diverging-colors-blue-pink)
   {
-    --visyn-#{$key}: #{$value};
+    --visyn-#{$key}:#{$value};
   }
 }

--- a/src/scss/abstracts/_vis_colors.scss
+++ b/src/scss/abstracts/_vis_colors.scss
@@ -147,6 +147,7 @@ $visyn-diverging-colors-blue-pink: (
     $visyn-diverging-colors-blue-yellow,
     $visyn-diverging-colors-blue-pink)
   {
+    // injecting without white-space as the value will be read with a leading white-space otherwise
     --visyn-#{$key}:#{$value};
   }
 }

--- a/src/utils/getCssValue.ts
+++ b/src/utils/getCssValue.ts
@@ -4,5 +4,5 @@
  * @returns the value which is stored in the css variable or undefined if the variable could not be found
  */
 export function getCssValue(name: string): string | undefined {
-  return getComputedStyle(document.documentElement).getPropertyValue(`--${name}`);
+  return getComputedStyle(document.documentElement).getPropertyValue(`--${name}`).trim();
 }


### PR DESCRIPTION
When injecting the css variable into root it is necessary to do it without a white-space, otherwise getCssValue() which reads the css variables from root returns the value with a leading white-space.