### PR TITLE
Align outline button to styleguide

### DIFF
--- a/dist/scss/components/_btn_text.scss
+++ b/dist/scss/components/_btn_text.scss
@@ -34,4 +34,13 @@
       $disabled-color: rgba($value, $btn-disabled-opacity)
     );
   }
+
+  // override the background color of button-outline-variant
+  .btn-outline-#{$color} {
+    @include button-outline-variant(
+      $color: $value,
+      $color-hover: $value,
+      $active-background: rgba($value, 0.10)
+    )
+  }
 }

--- a/src/scss/components/_btn_text.scss
+++ b/src/scss/components/_btn_text.scss
@@ -34,4 +34,13 @@
       $disabled-color: rgba($value, $btn-disabled-opacity)
     );
   }
+
+  // override the background color of button-outline-variant
+  .btn-outline-#{$color} {
+    @include button-outline-variant(
+      $color: $value,
+      $color-hover: $value,
+      $active-background: rgba($value, 0.10)
+    )
+  }
 }


### PR DESCRIPTION
This PR aligns the style of outline buttons to our styleguide.

This screencast shows the primary outline button (left button):

Before:
![outline-button-old](https://user-images.githubusercontent.com/57343176/151551072-9cdd7377-f19e-4eef-b4eb-ba43dc4b1b88.gif)

Now:
![outline-button](https://user-images.githubusercontent.com/57343176/151551063-5de3ada8-9e1b-461e-b7a3-1daa3f1da3f1.gif)
: