### PR TITLE
Invert active color for outline buttons

### DIFF
--- a/dist/scss/components/_btn_text.scss
+++ b/dist/scss/components/_btn_text.scss
@@ -40,6 +40,7 @@
     @include button-outline-variant(
       $color: $value,
       $color-hover: $value,
+      $active-color:  if(color-contrast($value) == $color-contrast-light, shade-color($value, $btn-active-bg-shade-amount), tint-color($value, $btn-active-bg-tint-amount)),
       $active-background: rgba($value, 0.10)
     )
   }

--- a/src/scss/components/_btn_text.scss
+++ b/src/scss/components/_btn_text.scss
@@ -40,6 +40,7 @@
     @include button-outline-variant(
       $color: $value,
       $color-hover: $value,
+      $active-color:  if(color-contrast($value) == $color-contrast-light, shade-color($value, $btn-active-bg-shade-amount), tint-color($value, $btn-active-bg-tint-amount)),
       $active-background: rgba($value, 0.10)
     )
   }


### PR DESCRIPTION
This PR inverts the color for outline buttons in active state and fixes #619.


### SCREENCAST
Primary button:
![outline-btn-active-color-primary](https://user-images.githubusercontent.com/57343176/153818631-ffc9c741-2083-4261-9c8b-90b2ea825b7d.gif)

Secondary button:
![outline-btn-active-color](https://user-images.githubusercontent.com/57343176/153818638-37193d95-fecc-4f4a-9e59-5d5c59f9d3fd.gif)
