### PR TITLE
Made nav-link background color dependent on theme color

### DIFF
--- a/dist/scss/components/_header_navbar.scss
+++ b/dist/scss/components/_header_navbar.scss
@@ -41,7 +41,7 @@
    * Colors light theme
    */
   &.navbar-light {
-    border-bottom: 1px solid $gray-400;
+    border-bottom: 1px solid shade-color(map-get($theme-colors, "light"), 10%);
 
     .navbar-brand {
       color: map-get($theme-colors, "dark");
@@ -53,13 +53,13 @@
       &:hover,
       &:focus,
       &.hover { // add .hover class to set state programmatically from TDP tours
-        background-color: $gray-400;
+        background-color: shade-color(map-get($theme-colors, "light"), 10%);
         color: map-get($theme-colors, "dark");
       }
     }
 
     .active > .nav-link {
-      background-color: $gray-400;
+      background-color: shade-color(map-get($theme-colors, "light"), 10%);
       color: map-get($theme-colors, "dark");
     }
   }
@@ -68,7 +68,7 @@
    * Colors dark theme
    */
   &.navbar-dark {
-    border-bottom-color: $gray-800;
+    border-bottom: 1px solid tint-color(map-get($theme-colors, "dark"), 10%);
 
     .navbar-brand {
       color: $white;
@@ -81,7 +81,7 @@
       &:hover,
       &:focus,
       &.hover { // add .hover class to set state programmatically from TDP tours
-        background-color: $gray-700;
+        background-color: tint-color(map-get($theme-colors, "dark"), 10%);
         color: map-get($theme-colors, "light");
       }
     }

--- a/src/scss/components/_header_navbar.scss
+++ b/src/scss/components/_header_navbar.scss
@@ -41,7 +41,7 @@
    * Colors light theme
    */
   &.navbar-light {
-    border-bottom: 1px solid $gray-400;
+    border-bottom: 1px solid shade-color(map-get($theme-colors, "light"), 10%);
 
     .navbar-brand {
       color: map-get($theme-colors, "dark");
@@ -53,13 +53,13 @@
       &:hover,
       &:focus,
       &.hover { // add .hover class to set state programmatically from TDP tours
-        background-color: $gray-400;
+        background-color: shade-color(map-get($theme-colors, "light"), 10%);
         color: map-get($theme-colors, "dark");
       }
     }
 
     .active > .nav-link {
-      background-color: $gray-400;
+      background-color: shade-color(map-get($theme-colors, "light"), 10%);
       color: map-get($theme-colors, "dark");
     }
   }
@@ -68,7 +68,7 @@
    * Colors dark theme
    */
   &.navbar-dark {
-    border-bottom-color: $gray-800;
+    border-bottom: 1px solid tint-color(map-get($theme-colors, "dark"), 10%);
 
     .navbar-brand {
       color: $white;
@@ -81,7 +81,7 @@
       &:hover,
       &:focus,
       &.hover { // add .hover class to set state programmatically from TDP tours
-        background-color: $gray-700;
+        background-color: tint-color(map-get($theme-colors, "dark"), 10%);
         color: map-get($theme-colors, "light");
       }
     }


### PR DESCRIPTION
Fixes #644 

**Summary**
Previously, the nav-link background and border color was just `gray-xxx` for the dark variant. When changing the the `$dark` color, this broke the styling. Now, the background is dependent on the theme color.

Dark:
* Before: 
![image](https://user-images.githubusercontent.com/51900829/154688992-4d82dc2e-a47a-445d-8231-8e1f994c668a.png)

* After: 
![image](https://user-images.githubusercontent.com/51900829/154688953-f7c741d1-49d9-4639-9e79-99cc509fa06d.png)

Light: 
* Before: 
![image](https://user-images.githubusercontent.com/51900829/154689091-c70cd9d8-c67d-4e77-b00d-e10614e3c738.png)

* After: 
![image](https://user-images.githubusercontent.com/51900829/154689200-e2a83c95-d7d9-4170-b0aa-c57885db3802.png)

Custom color (like `#10384F`):
* Before (**problem**): 
![image](https://user-images.githubusercontent.com/51900829/154689546-6d77ad26-a7f6-4a7b-80b3-449add76122e.png)

* After: 
![image](https://user-images.githubusercontent.com/51900829/154689386-fef4db7a-f611-4454-8fb4-a53fbf1edd78.png)
