### PR TITLE
Pin markupsafe==2.0.1 to avoid soft_unicode import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,8 @@ python-memcached==1.59
 flask-login==0.5.0
 redis~=3.5.3
 cachelib==0.1.1
+# Pin docutils to avoid AttributeError: 'Values' object has no attribute 'section_self_link'
 docutils==0.17.1
+# Pin markupsafe to avoid ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/usr/local/lib/python3.7/site-packages/markupsafe/__init__.py) 
+markupsafe==2.0.1
 -e git+https://github.com/phovea/phovea_server.git@develop#egg=phovea_server


### PR DESCRIPTION
Fixes build errors like `ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/home/circleci/venv/lib/python3.7/site-packages/markupsafe/__init__.py)`. 

See https://github.com/phovea/phovea_server/issues/154 for details. 