### PR TITLE
Changed top to 2em for lu-search in top-mode

### DIFF
--- a/dist/scss/components/_view_lineup.scss
+++ b/dist/scss/components/_view_lineup.scss
@@ -476,6 +476,7 @@ $lu_assets: "~lineupjs/src/assets";
 
       &.once .lu-search {
         left: -1.2em;
+        top: 2em;
       }
 
       &.once::before {

--- a/src/scss/components/_view_lineup.scss
+++ b/src/scss/components/_view_lineup.scss
@@ -476,6 +476,7 @@ $lu_assets: "~lineupjs/src/assets";
 
       &.once .lu-search {
         left: -1.2em;
+        top: 2em;
       }
 
       &.once::before {


### PR DESCRIPTION
Changed the `top` property for the lu-search back to 2em. It was changed to 2.4em [here ](https://github.com/datavisyn/tdp_core/commit/08163b8c033368436ea76f84656765d0274fe467) which broke the layout in top-mode. 

(ignore the hellip;)
![image](https://user-images.githubusercontent.com/51900829/155359477-bc981f81-ca9d-41b4-b334-48aaf94e9037.png) 

Otherwise, **nothing** changed, so no breaking changes whatsoever. 