### PR TITLE
Remove 1px border from dark navbar

### DIFF
--- a/dist/scss/components/_header_navbar.scss
+++ b/dist/scss/components/_header_navbar.scss
@@ -68,7 +68,7 @@
    * Colors dark theme
    */
   &.navbar-dark {
-    border-bottom: 1px solid tint-color(map-get($theme-colors, "dark"), 10%);
+    border-bottom-color: tint-color(map-get($theme-colors, "dark"), 10%);
 
     .navbar-brand {
       color: $white;

--- a/src/scss/components/_header_navbar.scss
+++ b/src/scss/components/_header_navbar.scss
@@ -68,7 +68,7 @@
    * Colors dark theme
    */
   &.navbar-dark {
-    border-bottom: 1px solid tint-color(map-get($theme-colors, "dark"), 10%);
+    border-bottom-color: tint-color(map-get($theme-colors, "dark"), 10%);
 
     .navbar-brand {
       color: $white;


### PR DESCRIPTION
Comin from Caleydo/tdp_bi_bioinfodb#1339

### Summary
* In a recent PR we added a border of 1px to the navbar dark causing https://github.com/Caleydo/tdp_bi_bioinfodb/issues/1339
* Reverted the change 

### Screenshot

![grafik](https://user-images.githubusercontent.com/51322092/156747301-a5f3fe92-3718-4086-8036-de86208fc663.png)
