### PR TITLE
Added jwt_token_location to configure where tokens should be looked for

### DIFF
--- a/tdp_core/security/manager.py
+++ b/tdp_core/security/manager.py
@@ -123,19 +123,21 @@ class SecurityManager:
             return None
 
     def load_from_request(self, request: Request):
-        # Load JWT user from Authorization header
-        scheme, token = get_authorization_scheme_param(request.headers.get("Authorization"))
-        if token and scheme.lower() == "bearer":
-            user = access_token_to_user(token)
-            if user:
-                return user
+        if "headers" in manager.settings.jwt_token_location:
+            # Load JWT user from Authorization header
+            scheme, token = get_authorization_scheme_param(request.headers.get(manager.settings.jwt_header_name))
+            if token and scheme.lower() == manager.settings.jwt_header_type:
+                user = access_token_to_user(token)
+                if user:
+                    return user
 
-        # Load JWT user from cookie
-        token_from_cookie = request.cookies.get(manager.settings.jwt_access_cookie_name)
-        if token_from_cookie:
-            user = access_token_to_user(token_from_cookie)
-            if user:
-                return user
+        if "cookies" in manager.settings.jwt_token_location:
+            # Load JWT user from cookie
+            token_from_cookie = request.cookies.get(manager.settings.jwt_access_cookie_name)
+            if token_from_cookie:
+                user = access_token_to_user(token_from_cookie)
+                if user:
+                    return user
 
         # Otherwise, login using the request
         user = self._load_from_key(request) or self._delegate_stores_until_not_none("load_from_request", request)

--- a/tdp_core/settings/model.py
+++ b/tdp_core/settings/model.py
@@ -28,14 +28,15 @@ class DisableSettings(BaseModel):
     extensions: List[str] = []
 
 
-class SecurityStoreSettings(BaseModel):
+class AlbSecurityStoreSettings(BaseModel):
     enable: bool = False
     cookie_name: Optional[str] = None
     signout_url: Optional[str] = None
 
 
 class SecurityStoreSettings(BaseModel):
-    alb_security_store: SecurityStoreSettings = SecurityStoreSettings()
+    alb_security_store: AlbSecurityStoreSettings = AlbSecurityStoreSettings()
+    """Settings for the ALB security store"""
 
 
 class SecuritySettings(BaseModel):
@@ -102,13 +103,20 @@ class TDPCoreSettings(BaseModel):
 class GlobalSettings(BaseSettings):
     env: Literal["development", "production"] = "development"
     secret_key: str = "VERY_SECRET_STUFF_T0IB84wlQrdMH8RVT28w"
+
+    # JWT options mostly inspired by flask-jwt-extended: https://flask-jwt-extended.readthedocs.io/en/stable/options/#general-options
+    jwt_token_location: List[str] = ["headers", "cookies"]
     jwt_expire_in_seconds: int = 24 * 60 * 60
     jwt_refresh_if_expiring_in_seconds: int = 30 * 60
     jwt_algorithm: str = "HS256"
     jwt_access_cookie_name: str = "dv_access_token"
+    jwt_header_name: str = "Authorization"
+    jwt_header_type: str = "Bearer"
     jwt_cookie_secure: bool = False
     jwt_cookie_samesite: str = "Strict"
     jwt_access_cookie_path: str = "/"
+
+    # General settings for tdp_core
     tdp_core: TDPCoreSettings = TDPCoreSettings()
 
     @property


### PR DESCRIPTION
Similar to https://flask-jwt-extended.readthedocs.io/en/stable/options/#JWT_TOKEN_LOCATION, this allows to set where JWT are looked for in a request. Possible options are `headers` and `cookies`. 

For example to only allow loading from cookies (ignoring any Authorization header, set `jwt_token_location: ['cookies']`. To disallow loading from any source (i.e. falling back to the security stores), set `jwt_token_location: []`.