### PR TITLE
Change default server command to not use debugpy

### DIFF
--- a/deploy/Dockerfile_dev
+++ b/deploy/Dockerfile_dev
@@ -13,7 +13,7 @@ RUN echo '#!/bin/sh\npip install --no-cache-dir --no-deps -r /phovea/requirement
 RUN chmod +x /tmp/entrypoint.sh
 ENTRYPOINT [ "/tmp/entrypoint.sh" ]
 
-# Default command is to start the server in debug mode
-CMD [ "python -m debugpy --listen 0.0.0.0:5678 -m uvicorn tdp_core.server.main:app --reload --host 0.0.0.0 --port 9000"]
+# Default command is to start the server
+CMD [ "python -m uvicorn tdp_core.server.main:app --reload --host 0.0.0.0 --port 9000" ]
 
 EXPOSE 9000

--- a/deploy/docker-compose-debug.partial.yml
+++ b/deploy/docker-compose-debug.partial.yml
@@ -3,3 +3,6 @@ services:
   db_mongo:
     ports:
       - '27017:27017'
+  api:
+    # Override the default server command to add a debugging process. This causes the app to run slower, therefore it is optional.
+    command: 'python -m debugpy --listen 0.0.0.0:5678 -m uvicorn tdp_core.server.main:app --reload --host 0.0.0.0 --port 9000'

--- a/tdp_core/dbmanager.py
+++ b/tdp_core/dbmanager.py
@@ -94,10 +94,10 @@ class DBManager(object):
         session = self.create_session(engine_or_id)
 
         try:
-            existing_session = get_request().state.db_sessions
+            existing_sessions = get_request().state.db_sessions
         except (KeyError, AttributeError):
-            existing_session = []
-            get_request().state.db_sessions = existing_session
-        existing_session.append(session)
+            existing_sessions = []
+            get_request().state.db_sessions = existing_sessions
+        existing_sessions.append(session)
 
         return session


### PR DESCRIPTION
debugpy (the debugger attached to the main uvicorn process to allow remote debugging via F5) is reducing the performance (around ~3-5x in our tests), even [if no debugger is attached](https://github.com/microsoft/debugpy/issues/204). Therefore, we move it to the `./docker-compose-debug up` script instead of the `docker-compose up`. 

To run the container in normal mode, use `docker-compose up`, to run it with the debugger process, use `./docker-compose-debug up`.