### PR TITLE
Pin lineupjs to 4.6.0 to avoid installing 4.6.1 which contains fontaw…

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eventemitter3": "^4.0.7",
     "i18next": "^19.8.4",
     "jquery": "~3.5.1",
-    "lineupjs": "~4.6.0",
+    "lineupjs": "4.6.0",
     "lodash": "~4.17.20",
     "marked": "~3.0.2",
     "md5": "^2.3.0",


### PR DESCRIPTION
…esome 6