### PR TITLE
Do not close login dialog on escape

### DIFF
--- a/dist/base/LoginMenu.js
+++ b/dist/base/LoginMenu.js
@@ -93,7 +93,7 @@ export class LoginMenu extends EventHandler {
         }
         body.insertAdjacentHTML('beforeend', `
       <!--login dialog-->
-      <div class="modal fade" id="loginDialog" tabindex="-1" role="dialog" aria-labelledby="loginDialog" data-keyboard="false" data-bs-backdrop="static">
+      <div class="modal fade" id="loginDialog" tabindex="-1" role="dialog" aria-labelledby="loginDialog" data-bs-keyboard="false" data-bs-backdrop="static">
         <div class="modal-dialog modal-sm">
           <div class="modal-content">
             <div class="modal-header">

--- a/src/base/LoginMenu.ts
+++ b/src/base/LoginMenu.ts
@@ -133,7 +133,7 @@ export class LoginMenu extends EventHandler {
       'beforeend',
       `
       <!--login dialog-->
-      <div class="modal fade" id="loginDialog" tabindex="-1" role="dialog" aria-labelledby="loginDialog" data-keyboard="false" data-bs-backdrop="static">
+      <div class="modal fade" id="loginDialog" tabindex="-1" role="dialog" aria-labelledby="loginDialog" data-bs-keyboard="false" data-bs-backdrop="static">
         <div class="modal-dialog modal-sm">
           <div class="modal-content">
             <div class="modal-header">


### PR DESCRIPTION

### Summary
* Added the correct bs class to login dialog
* see bs [documentation](https://getbootstrap.com/docs/5.1/components/modal/#options)

The issue is that the login dialog can be closed when you hit escape,
see the below grafik for a screencast of the issue

![grafik](https://user-images.githubusercontent.com/51322092/173029142-59d690a8-4080-440f-bb70-f8c9f4d0671f.gif)
