### PR TITLE
Add NODE_OPTIONS=--max_old_space_size=4096  to storybook scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
             node -v
             npm -v
       - restore_cache:
-          key: deps1-{{ .Branch }}-{{ checksum "package.json" }}
+          key: deps2-{{ .Branch }}-{{ checksum "package.json" }}
       - run:
           name: Install npm dependencies
           command: npm install
@@ -101,7 +101,7 @@ jobs:
           command: |
             (grep -l '._resolved.: .\(git[^:]*\|bitbucket\):' ./node_modules/*/package.json || true) | xargs -r dirname | xargs -r rm -rf
       - save_cache:
-          key: deps1-{{ .Branch }}-{{ checksum "package.json" }}
+          key: deps2-{{ .Branch }}-{{ checksum "package.json" }}
           paths: ./node_modules
       - run:
           name: Install npm dependencies from git repositories (always get latest commit)

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "node": ">= 12.13"
   },
   "scripts": {
-    "build": "npm run clean && npm run compile && npm run storybook:build",
+    "build": "npm run clean && npm run compile",
     "clean": "rimraf build dist lib",
     "compile:watch": "tsc -w",
     "compile": "tsc",
@@ -101,7 +101,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.17.7",
-    "@babel/plugin-transform-typescript": "7.17.12",
     "@storybook/addon-actions": "^6.5.9",
     "@storybook/addon-essentials": "^6.5.9",
     "@storybook/addon-interactions": "^6.5.9",

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "test:watch": "jest --watch",
     "test": "test ! $(find tests -name \"*.ts\") || jest -w=1",
     "make": "make --",
-    "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "storybook": "NODE_OPTIONS=--max_old_space_size=4096 start-storybook -p 6006",
+    "storybook:build": "NODE_OPTIONS=--max_old_space_size=4096 build-storybook"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "node": ">= 12.13"
   },
   "scripts": {
-    "build": "npm run clean && npm run compile && npm run build-storybook",
+    "build": "npm run clean && npm run compile && npm run storybook:build",
     "clean": "rimraf build dist lib",
     "compile:watch": "tsc -w",
     "compile": "tsc",


### PR DESCRIPTION
Because tdp_core is so large, storybook needs some more memory to build it. We also removed it from the automated build as storybook is breaking.