### PR TITLE
Fixed return value of logout of ALB security store

### DIFF
--- a/tdp_core/security/store/alb_security_store.py
+++ b/tdp_core/security/store/alb_security_store.py
@@ -4,7 +4,7 @@ from typing import Optional
 import jwt
 
 from ... import manager
-from ..model import User
+from ..model import LogoutReturnValue, User
 from .base_store import BaseStore
 
 _log = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ class ALBSecurityStore(BaseStore):
         if self.signout_url:
             payload["alb_security_store"] = {"redirect": self.signout_url}
 
-        return {"data": payload, "cookies": cookies}
+        return LogoutReturnValue(data=payload, cookies=cookies)
 
 
 def create():


### PR DESCRIPTION
Fixes #745 

## Summary

When we migrated to FastAPI, we forgot to change the return value of the logout function of the ALB security store. Now it returns the properly typed model and adds unit tests. 