### PR TITLE
Show selection indicator next to scroll bar in rankings

### DIFF
--- a/dist/scss/components/_view_lineup.scss
+++ b/dist/scss/components/_view_lineup.scss
@@ -59,7 +59,7 @@
 .lineup-engine {
   position: absolute;
   top: 0;
-  right: 0;
+  right: 4px; // leave some space for the LineUp selection indicator next to the scroll bar
   bottom: 0;
   left: 0;
   overflow: auto;

--- a/src/scss/components/_view_lineup.scss
+++ b/src/scss/components/_view_lineup.scss
@@ -59,7 +59,7 @@
 .lineup-engine {
   position: absolute;
   top: 0;
-  right: 0;
+  right: 4px; // leave some space for the LineUp selection indicator next to the scroll bar
   bottom: 0;
   left: 0;
   overflow: auto;


### PR DESCRIPTION
### Summary

* Show selection indicator next to scroll bar for every LineUp ranking

![grafik](https://user-images.githubusercontent.com/5851088/180083596-58571690-2cc1-45f1-9190-ee2e843ff8f5.png)
