### PR TITLE
Fix SCSS warning for divide numbers using `/`

### DIFF
--- a/dist/scss/components/_namedsetlist.scss
+++ b/dist/scss/components/_namedsetlist.scss
@@ -7,7 +7,7 @@
   .custom-named-sets header::before,
   .other-named-sets header::before {
     @extend .fas;
-    width: (18em / 14);
+    width: calc(18em / 14);
     text-align: center;
   }
 

--- a/src/scss/components/_namedsetlist.scss
+++ b/src/scss/components/_namedsetlist.scss
@@ -7,7 +7,7 @@
   .custom-named-sets header::before,
   .other-named-sets header::before {
     @extend .fas;
-    width: (18em / 14);
+    width: calc(18em / 14);
     text-align: center;
   }
 


### PR DESCRIPTION
This PR fixes the following SCSS compiler warning:

```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(18em, 14) or calc(18em / 14)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
10 │     width: (18em / 14);
   │             ^^^^^^^^^
   ╵
    tdp_core/dist/scss/components/_namedsetlist.scss 10:13  @import
    tdp_core/dist/scss/main.scss 21:9                       @import
    workspace.scss 39:9                                     root stylesheet
```

Please note that this PR only fixes the warning from SCSS files in tdp_core. It does not fix the warnings from Font Awesome SCSS files; they will be fixed with #732.