### PR TITLE
refactor: Avoid general aside styles caused by CLUE

### DIFF
--- a/dist/scss/_clue_override.scss
+++ b/dist/scss/_clue_override.scss
@@ -13,13 +13,11 @@ header.clue-modeselector {
 
 // overrides caleydo_clue/styles/base
 aside {
-  border: 0;
-  border-left: 2px solid $core_colour_selected;
-  border-radius: 0;
-  margin: 0;
-
   &.provenance-layout-vis {
-    border-color: $core_colour_selected;
+    border: 0;
+    border-left: 2px solid $core_colour_selected;
+    border-radius: 0;
+    margin: 0;
 
     &.collapsed {
       border-left: 0; // hide border when panel is collapsed
@@ -27,11 +25,17 @@ aside {
   }
 
   &.provenance-story-vis {
-    border-color: $core_colour_selected;
+    border: 0;
+    border-left: 2px solid $core_colour_selected;
+    border-radius: 0;
+    margin: 0;
   }
 
   &.annotations {
+    border-radius: 0;
+    margin: 0;
     border: 2px solid $core_colour_selected;
+
     > div:first-of-type {
       background-color: $presentation-stage;
     }

--- a/src/scss/_clue_override.scss
+++ b/src/scss/_clue_override.scss
@@ -13,13 +13,11 @@ header.clue-modeselector {
 
 // overrides caleydo_clue/styles/base
 aside {
-  border: 0;
-  border-left: 2px solid $core_colour_selected;
-  border-radius: 0;
-  margin: 0;
-
   &.provenance-layout-vis {
-    border-color: $core_colour_selected;
+    border: 0;
+    border-left: 2px solid $core_colour_selected;
+    border-radius: 0;
+    margin: 0;
 
     &.collapsed {
       border-left: 0; // hide border when panel is collapsed
@@ -27,11 +25,17 @@ aside {
   }
 
   &.provenance-story-vis {
-    border-color: $core_colour_selected;
+    border: 0;
+    border-left: 2px solid $core_colour_selected;
+    border-radius: 0;
+    margin: 0;
   }
 
   &.annotations {
+    border-radius: 0;
+    margin: 0;
     border: 2px solid $core_colour_selected;
+
     > div:first-of-type {
       background-color: $presentation-stage;
     }


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

* Avoid general `<aside>` styles
* Copy general aside styles into nested panels

### Screenshots

No changes to current implementation


Thanks for creating this pull request 🤗
