### PR TITLE
Override form_check to write print-color-adjust instead of color-adjust

### DIFF
--- a/dist/scss/components/_view.scss
+++ b/dist/scss/components/_view.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .#{$tdp-css-prefix}-view {
   &.multiple {
     overflow-y: auto;
@@ -37,8 +39,8 @@
       position: absolute;
       top: 50%;
       left: 50%;
-      margin-left: -$nothing/2;
-      margin-top: -$nothing/2;
+      margin-left: math.div(-$nothing, 2);
+      margin-top: math.div(-$nothing, 2);
       font-size: $nothing;
       z-index: 9;
     }

--- a/dist/scss/vendors/bootstrap/_2_components.scss
+++ b/dist/scss/vendors/bootstrap/_2_components.scss
@@ -22,7 +22,7 @@
 @import "~bootstrap/scss/close";
 @import "~bootstrap/scss/containers";
 @import "~bootstrap/scss/dropdown";
-@import "~bootstrap/scss/forms";
+@import "./overrides/forms";
 @import "~bootstrap/scss/grid";
 @import "~bootstrap/scss/images";
 @import "~bootstrap/scss/list-group";

--- a/dist/scss/vendors/bootstrap/overrides/_form_check.scss
+++ b/dist/scss/vendors/bootstrap/overrides/_form_check.scss
@@ -1,0 +1,154 @@
+//
+// Check/radio
+//
+
+.form-check {
+    display: block;
+    min-height: $form-check-min-height;
+    padding-left: $form-check-padding-start;
+    margin-bottom: $form-check-margin-bottom;
+  
+    .form-check-input {
+      float: left;
+      margin-left: $form-check-padding-start * -1;
+    }
+  }
+  
+  .form-check-input {
+    width: $form-check-input-width;
+    height: $form-check-input-width;
+    margin-top: ($line-height-base - $form-check-input-width) * .5; // line-height minus check height
+    vertical-align: top;
+    background-color: $form-check-input-bg;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: contain;
+    border: $form-check-input-border;
+    appearance: none;
+    // This was changed from color-adjust to print-color-adjust to avoid a warning of autoprefixer: https://github.com/twbs/bootstrap/issues/36259
+    print-color-adjust: exact; // Keep themed appearance for print
+    @include transition($form-check-transition);
+  
+    &[type="checkbox"] {
+      @include border-radius($form-check-input-border-radius);
+    }
+  
+    &[type="radio"] {
+      // stylelint-disable-next-line property-disallowed-list
+      border-radius: $form-check-radio-border-radius;
+    }
+  
+    &:active {
+      filter: $form-check-input-active-filter;
+    }
+  
+    &:focus {
+      border-color: $form-check-input-focus-border;
+      outline: 0;
+      box-shadow: $form-check-input-focus-box-shadow;
+    }
+  
+    &:checked {
+      background-color: $form-check-input-checked-bg-color;
+      border-color: $form-check-input-checked-border-color;
+  
+      &[type="checkbox"] {
+        @if $enable-gradients {
+          background-image: escape-svg($form-check-input-checked-bg-image), var(--#{$variable-prefix}gradient);
+        } @else {
+          background-image: escape-svg($form-check-input-checked-bg-image);
+        }
+      }
+  
+      &[type="radio"] {
+        @if $enable-gradients {
+          background-image: escape-svg($form-check-radio-checked-bg-image), var(--#{$variable-prefix}gradient);
+        } @else {
+          background-image: escape-svg($form-check-radio-checked-bg-image);
+        }
+      }
+    }
+  
+    &[type="checkbox"]:indeterminate {
+      background-color: $form-check-input-indeterminate-bg-color;
+      border-color: $form-check-input-indeterminate-border-color;
+  
+      @if $enable-gradients {
+        background-image: escape-svg($form-check-input-indeterminate-bg-image), var(--#{$variable-prefix}gradient);
+      } @else {
+        background-image: escape-svg($form-check-input-indeterminate-bg-image);
+      }
+    }
+  
+    &:disabled {
+      pointer-events: none;
+      filter: none;
+      opacity: $form-check-input-disabled-opacity;
+    }
+  
+    // Use disabled attribute in addition of :disabled pseudo-class
+    // See: https://github.com/twbs/bootstrap/issues/28247
+    &[disabled],
+    &:disabled {
+      ~ .form-check-label {
+        opacity: $form-check-label-disabled-opacity;
+      }
+    }
+  }
+  
+  .form-check-label {
+    color: $form-check-label-color;
+    cursor: $form-check-label-cursor;
+  }
+  
+  //
+  // Switch
+  //
+  
+  .form-switch {
+    padding-left: $form-switch-padding-start;
+  
+    .form-check-input {
+      width: $form-switch-width;
+      margin-left: $form-switch-padding-start * -1;
+      background-image: escape-svg($form-switch-bg-image);
+      background-position: left center;
+      @include border-radius($form-switch-border-radius);
+      @include transition($form-switch-transition);
+  
+      &:focus {
+        background-image: escape-svg($form-switch-focus-bg-image);
+      }
+  
+      &:checked {
+        background-position: $form-switch-checked-bg-position;
+  
+        @if $enable-gradients {
+          background-image: escape-svg($form-switch-checked-bg-image), var(--#{$variable-prefix}gradient);
+        } @else {
+          background-image: escape-svg($form-switch-checked-bg-image);
+        }
+      }
+    }
+  }
+  
+  .form-check-inline {
+    display: inline-block;
+    margin-right: $form-check-inline-margin-end;
+  }
+  
+  .btn-check {
+    position: absolute;
+    clip: rect(0, 0, 0, 0);
+    pointer-events: none;
+  
+    &[disabled],
+    &:disabled {
+      + .btn {
+        pointer-events: none;
+        filter: none;
+        opacity: $form-check-btn-check-disabled-opacity;
+      }
+    }
+  }
+  

--- a/dist/scss/vendors/bootstrap/overrides/_forms.scss
+++ b/dist/scss/vendors/bootstrap/overrides/_forms.scss
@@ -1,0 +1,9 @@
+@import "~bootstrap/scss/forms/labels";
+@import "~bootstrap/scss/forms/form-text";
+@import "~bootstrap/scss/forms/form-control";
+@import "~bootstrap/scss/forms/form-select";
+@import "./form_check";
+@import "~bootstrap/scss/forms/form-range";
+@import "~bootstrap/scss/forms/floating-labels";
+@import "~bootstrap/scss/forms/input-group";
+@import "~bootstrap/scss/forms/validation";

--- a/src/scss/components/_view.scss
+++ b/src/scss/components/_view.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .#{$tdp-css-prefix}-view {
   &.multiple {
     overflow-y: auto;
@@ -37,8 +39,8 @@
       position: absolute;
       top: 50%;
       left: 50%;
-      margin-left: -$nothing/2;
-      margin-top: -$nothing/2;
+      margin-left: math.div(-$nothing, 2);
+      margin-top: math.div(-$nothing, 2);
       font-size: $nothing;
       z-index: 9;
     }

--- a/src/scss/vendors/bootstrap/_2_components.scss
+++ b/src/scss/vendors/bootstrap/_2_components.scss
@@ -22,7 +22,7 @@
 @import "~bootstrap/scss/close";
 @import "~bootstrap/scss/containers";
 @import "~bootstrap/scss/dropdown";
-@import "~bootstrap/scss/forms";
+@import "./overrides/forms";
 @import "~bootstrap/scss/grid";
 @import "~bootstrap/scss/images";
 @import "~bootstrap/scss/list-group";

--- a/src/scss/vendors/bootstrap/overrides/_form_check.scss
+++ b/src/scss/vendors/bootstrap/overrides/_form_check.scss
@@ -1,0 +1,154 @@
+//
+// Check/radio
+//
+
+.form-check {
+    display: block;
+    min-height: $form-check-min-height;
+    padding-left: $form-check-padding-start;
+    margin-bottom: $form-check-margin-bottom;
+  
+    .form-check-input {
+      float: left;
+      margin-left: $form-check-padding-start * -1;
+    }
+  }
+  
+  .form-check-input {
+    width: $form-check-input-width;
+    height: $form-check-input-width;
+    margin-top: ($line-height-base - $form-check-input-width) * .5; // line-height minus check height
+    vertical-align: top;
+    background-color: $form-check-input-bg;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: contain;
+    border: $form-check-input-border;
+    appearance: none;
+    // This was changed from color-adjust to print-color-adjust to avoid a warning of autoprefixer: https://github.com/twbs/bootstrap/issues/36259
+    print-color-adjust: exact; // Keep themed appearance for print
+    @include transition($form-check-transition);
+  
+    &[type="checkbox"] {
+      @include border-radius($form-check-input-border-radius);
+    }
+  
+    &[type="radio"] {
+      // stylelint-disable-next-line property-disallowed-list
+      border-radius: $form-check-radio-border-radius;
+    }
+  
+    &:active {
+      filter: $form-check-input-active-filter;
+    }
+  
+    &:focus {
+      border-color: $form-check-input-focus-border;
+      outline: 0;
+      box-shadow: $form-check-input-focus-box-shadow;
+    }
+  
+    &:checked {
+      background-color: $form-check-input-checked-bg-color;
+      border-color: $form-check-input-checked-border-color;
+  
+      &[type="checkbox"] {
+        @if $enable-gradients {
+          background-image: escape-svg($form-check-input-checked-bg-image), var(--#{$variable-prefix}gradient);
+        } @else {
+          background-image: escape-svg($form-check-input-checked-bg-image);
+        }
+      }
+  
+      &[type="radio"] {
+        @if $enable-gradients {
+          background-image: escape-svg($form-check-radio-checked-bg-image), var(--#{$variable-prefix}gradient);
+        } @else {
+          background-image: escape-svg($form-check-radio-checked-bg-image);
+        }
+      }
+    }
+  
+    &[type="checkbox"]:indeterminate {
+      background-color: $form-check-input-indeterminate-bg-color;
+      border-color: $form-check-input-indeterminate-border-color;
+  
+      @if $enable-gradients {
+        background-image: escape-svg($form-check-input-indeterminate-bg-image), var(--#{$variable-prefix}gradient);
+      } @else {
+        background-image: escape-svg($form-check-input-indeterminate-bg-image);
+      }
+    }
+  
+    &:disabled {
+      pointer-events: none;
+      filter: none;
+      opacity: $form-check-input-disabled-opacity;
+    }
+  
+    // Use disabled attribute in addition of :disabled pseudo-class
+    // See: https://github.com/twbs/bootstrap/issues/28247
+    &[disabled],
+    &:disabled {
+      ~ .form-check-label {
+        opacity: $form-check-label-disabled-opacity;
+      }
+    }
+  }
+  
+  .form-check-label {
+    color: $form-check-label-color;
+    cursor: $form-check-label-cursor;
+  }
+  
+  //
+  // Switch
+  //
+  
+  .form-switch {
+    padding-left: $form-switch-padding-start;
+  
+    .form-check-input {
+      width: $form-switch-width;
+      margin-left: $form-switch-padding-start * -1;
+      background-image: escape-svg($form-switch-bg-image);
+      background-position: left center;
+      @include border-radius($form-switch-border-radius);
+      @include transition($form-switch-transition);
+  
+      &:focus {
+        background-image: escape-svg($form-switch-focus-bg-image);
+      }
+  
+      &:checked {
+        background-position: $form-switch-checked-bg-position;
+  
+        @if $enable-gradients {
+          background-image: escape-svg($form-switch-checked-bg-image), var(--#{$variable-prefix}gradient);
+        } @else {
+          background-image: escape-svg($form-switch-checked-bg-image);
+        }
+      }
+    }
+  }
+  
+  .form-check-inline {
+    display: inline-block;
+    margin-right: $form-check-inline-margin-end;
+  }
+  
+  .btn-check {
+    position: absolute;
+    clip: rect(0, 0, 0, 0);
+    pointer-events: none;
+  
+    &[disabled],
+    &:disabled {
+      + .btn {
+        pointer-events: none;
+        filter: none;
+        opacity: $form-check-btn-check-disabled-opacity;
+      }
+    }
+  }
+  

--- a/src/scss/vendors/bootstrap/overrides/_forms.scss
+++ b/src/scss/vendors/bootstrap/overrides/_forms.scss
@@ -1,0 +1,9 @@
+@import "~bootstrap/scss/forms/labels";
+@import "~bootstrap/scss/forms/form-text";
+@import "~bootstrap/scss/forms/form-control";
+@import "~bootstrap/scss/forms/form-select";
+@import "./form_check";
+@import "~bootstrap/scss/forms/form-range";
+@import "~bootstrap/scss/forms/floating-labels";
+@import "~bootstrap/scss/forms/input-group";
+@import "~bootstrap/scss/forms/validation";

--- a/workspace.scss
+++ b/workspace.scss
@@ -1,3 +1,2 @@
 // Use the storybook entrypoint to load variables etc.
 @import './src/scss/storybook.scss';
-@import './src/scss/main.scss';


### PR DESCRIPTION
Override form_check.scss from bootstrap to write print-color-adjust instead of color-adjust. color-adjust is deprecated and triggers a warning, causing the webpack cache to become slower. See https://github.com/twbs/bootstrap/issues/36259 for more details. 

### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] ~~Requires UI/UX/Vis review~~
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Adds `_form_check.scss` which fixes the color-adjust autoprefixer warning. 
- Fixes some division warnings by using math.div

-  
Thanks for creating this pull request 🤗
