### PR TITLE
Pin plotly.js-dist-min to 2.12 to avoid selection error

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "marked": "~3.0.2",
     "md5": "^2.3.0",
     "papaparse": "~5.3.0",
-    "plotly.js-dist-min": "^2.8.3",
+    "plotly.js-dist-min": "~2.12.0",
     "popper.js": "^1.15.0",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] ~~Requires UI/UX/Vis review~~
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [x] Unit tests are written (frontend/backend if applicable)
- [x] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

Pins plotly.js-dist-min to 2.12 to avoid selection regression. Plotly 2.13 introduced a "breaking" change where a selection event is triggered *after* the previous selection event with empty points (and also no lasso property). Because this is breaking some of our plots (as we don't know for what property to check yet), we should downgrade plotly. 

This is the release: https://github.com/plotly/plotly.js/releases/tag/v2.13.0 and here are some issues mentioning this problem https://github.com/plotly/plotly.js/issues/6295 and https://github.com/plotly/plotly.js/issues/6294

### Additional notes for the reviewer(s)

Non-breaking change, just a downgrade. 

-  
Thanks for creating this pull request 🤗
