### PR TITLE
Added no security store for static logins

### DIFF
--- a/tdp_core/__init__.py
+++ b/tdp_core/__init__.py
@@ -81,11 +81,16 @@ class VisynPlugin(AVisynPlugin):
         )
 
         # phovea_security_flask
-        # TODO: Add ENV variables to allow disabling
         registry.append(
             "user_stores",
             "alb_security_store",
             "tdp_core.security.store.alb_security_store",
+            {},
+        )
+        registry.append(
+            "user_stores",
+            "no_security_store",
+            "tdp_core.security.store.no_security_store",
             {},
         )
 

--- a/tdp_core/security/store/no_security_store.py
+++ b/tdp_core/security/store/no_security_store.py
@@ -1,0 +1,32 @@
+import logging
+from typing import List
+
+from ... import manager
+from ..model import User
+from .base_store import BaseStore
+
+_log = logging.getLogger(__name__)
+
+
+class NoSecurityStore(BaseStore):
+    def __init__(self, user: str, roles: List[str]):
+        self.user = user
+        self.roles = roles
+
+    def load_from_request(self, req):
+        return User(id=self.user, roles=self.roles)
+
+
+def create():
+    # Check if the security store is enabled.
+    # Why do we do this here and not in the __init__.py?
+    # Because the configuration is merged after the registry is loaded,
+    # such that no keys are available (except tdp_core keys).
+    if manager.settings.tdp_core.security.store.no_security_store.enable:
+        _log.info("Adding NoSecurityStore")
+        return NoSecurityStore(
+            manager.settings.tdp_core.security.store.no_security_store.user,
+            manager.settings.tdp_core.security.store.no_security_store.roles,
+        )
+
+    return None

--- a/tdp_core/settings/model.py
+++ b/tdp_core/settings/model.py
@@ -33,9 +33,17 @@ class AlbSecurityStoreSettings(BaseModel):
     signout_url: Optional[str] = None
 
 
+class NoSecurityStoreSettings(BaseModel):
+    enable: bool = False
+    user: str = "admin"
+    roles: List[str] = []
+
+
 class SecurityStoreSettings(BaseModel):
     alb_security_store: AlbSecurityStoreSettings = AlbSecurityStoreSettings()
     """Settings for the ALB security store"""
+    no_security_store: NoSecurityStoreSettings = NoSecurityStoreSettings()
+    """Settings for the no security store"""
 
 
 class SecuritySettings(BaseModel):


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [x] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Adds a `NoSecurityStore` (disabled by default), which always returns the same user for every request, i.e. it completely skips the login part. Only use this if no authentication is required at all. Look at the configuration to change the corresponding user id or roles.

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
