### PR TITLE
Bump rdkit to 2022.3.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ uvicorn[standard]==0.17.6
 yamlreader==3.0.4
 pytest-postgresql==4.1.1
 psycopg==3.0.16
-rdkit==2022.3.3
+rdkit==2022.3.5

--- a/tdp_core/tests/test_rdkit_img.py
+++ b/tdp_core/tests/test_rdkit_img.py
@@ -47,7 +47,7 @@ def test_align(client: TestClient):
 
 def test_substructure(client: TestClient):
     res = client.get("/api/rdkit/", params={"structure": "C", "substructure": "C"})
-    hash_compare(res.content, "7b22e41b1fdf3385454b6ae2655e13e49436ce9812e7392bbc389f4f149b055c")
+    hash_compare(res.content, "715c3f878882d5190eae7ec84b3cf937456f2840618256994fc6b2e9d02498ab")
 
 
 def test_murcko(client: TestClient):
@@ -70,7 +70,7 @@ def test_similarity(client: TestClient, mol, ref, expected):
 def test_maximum_common_substructure(client: TestClient):
     res = client.post("/api/rdkit/mcs/", json=["C#CCP", "C=CCO"])
     assert res.status_code == 200
-    hash_compare(res.content, "97d425b6bbe74b15f2b72e2fde973b0780f301281b1a7b2ee154bb0f3dd86c20")
+    hash_compare(res.content, "94f655f787f55ebdf8bf1b85a63ed50652969ce718ffeb89a6289e739b078e3d")
 
 
 def test_maximum_common_substructure_inconsistent(client: TestClient):


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [x] Unit tests are written (frontend/backend if applicable)
- [x] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Updates RDKit to the latest version (no breaking changes).
- Two hashes had to be updated, see below for the direct comparison. 

### Screenshots

Before:
![Screenshot from 2022-09-01 08-37-27](https://user-images.githubusercontent.com/51900829/187848972-c4cf0c77-74a7-4733-8c8f-1b56f11024c2.png)

After:
![Screenshot from 2022-09-01 08-38-01](https://user-images.githubusercontent.com/51900829/187849041-d545d67a-a5aa-401b-a992-cc75d3420fc3.png)


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
