### PR TITLE
Fix missing lineup color mappings by adjusting styles

### DIFF
--- a/dist/scss/vendors/_lineup.scss
+++ b/dist/scss/vendors/_lineup.scss
@@ -112,9 +112,12 @@ $lu_include_font_awesome: false !default;
 .lu-dialog {
   .lu-checkbox {
     display: flex;
-    align-items: baseline;
     gap: 5px;
     margin: unset;
+  }
+
+  .lu-color-gradient {
+    margin: 5px;
   }
 }
 

--- a/src/scss/vendors/_lineup.scss
+++ b/src/scss/vendors/_lineup.scss
@@ -112,9 +112,12 @@ $lu_include_font_awesome: false !default;
 .lu-dialog {
   .lu-checkbox {
     display: flex;
-    align-items: baseline;
     gap: 5px;
     margin: unset;
+  }
+
+  .lu-color-gradient {
+    margin: 5px;
   }
 }
 


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Changes styles applied to `.lu-checkbox` such that color gradients in the color mapping dialog are visible again.

### Screenshots

#### Before
![image](https://user-images.githubusercontent.com/51900829/196908539-4fc8aa42-1e75-4c95-8d84-32b6adb0cd8f.png)

#### After
![image](https://user-images.githubusercontent.com/51900829/196908727-4c36dd87-ea74-4368-b19a-0b6668d31619.png)


### Additional notes for the reviewer(s)

- Briefly test in your application. Note that checkbox labels are now not aligned `baseline` anymore, but this is not problematic.

Thanks for creating this pull request 🤗
