### PR TITLE
fix: Plotly type error with `violingap`

### DIFF
--- a/src/vis/bar/BarVis.tsx
+++ b/src/vis/bar/BarVis.tsx
@@ -160,7 +160,7 @@ export function BarVis({
       return null;
     }
 
-    const innerLayout: Plotly.Layout = {
+    const innerLayout: Partial<Plotly.Layout> = {
       showlegend: true,
       legend: {
         // @ts-ignore
@@ -173,7 +173,6 @@ export function BarVis({
       autosize: true,
       grid: { rows: finalTraces.rows, columns: finalTraces.cols, xgap: 0.3, pattern: 'independent' },
       shapes: [],
-      violingap: 0,
       barmode: config.groupType === EBarGroupingType.STACK ? 'stack' : 'group',
       dragmode: false,
     };

--- a/src/vis/general/layoutUtils.ts
+++ b/src/vis/general/layoutUtils.ts
@@ -20,7 +20,7 @@ export function columnNameWithDescription(col: ColumnInfo) {
  * @param layout the current layout to be changed. Typed to any because the plotly types complain.p
  * @returns the changed layout
  */
-export function beautifyLayout(traces: PlotlyInfo, layout: Plotly.Layout) {
+export function beautifyLayout(traces: PlotlyInfo, layout: Partial<Plotly.Layout>) {
   const layoutEdit = layout;
   layoutEdit.annotations = [];
   traces.plots.forEach((t, i) => {

--- a/src/vis/scatter/ScatterVis.tsx
+++ b/src/vis/scatter/ScatterVis.tsx
@@ -111,7 +111,7 @@ export function ScatterVis({
       return null;
     }
 
-    const innerLayout: Plotly.Layout = {
+    const innerLayout: Partial<Plotly.Layout> = {
       showlegend: true,
       legend: {
         // @ts-ignore
@@ -128,7 +128,6 @@ export function ScatterVis({
       autosize: true,
       grid: { rows: traces.rows, columns: traces.cols, xgap: 0.3, pattern: 'independent' },
       shapes: [],
-      violingap: 0,
       dragmode: config.dragMode,
     };
 

--- a/src/vis/strip/StripVis.tsx
+++ b/src/vis/strip/StripVis.tsx
@@ -88,7 +88,7 @@ export function StripVis({
       return null;
     }
 
-    const innerLayout: Plotly.Layout = {
+    const innerLayout: Partial<Plotly.Layout> = {
       showlegend: true,
       legend: {
         // @ts-ignore
@@ -101,7 +101,6 @@ export function StripVis({
       autosize: true,
       grid: { rows: traces.rows, columns: traces.cols, xgap: 0.3, pattern: 'independent' },
       shapes: [],
-      violingap: 0,
       dragmode: 'select',
     };
 

--- a/src/vis/violin/ViolinVis.tsx
+++ b/src/vis/violin/ViolinVis.tsx
@@ -92,7 +92,7 @@ export function ViolinVis({
       return null;
     }
 
-    const innerLayout: Plotly.Layout = {
+    const innerLayout: Partial<Plotly.Layout> = {
       showlegend: true,
       legend: {
         // @ts-ignore
@@ -105,7 +105,6 @@ export function ViolinVis({
       autosize: true,
       grid: { rows: traces.rows, columns: traces.cols, xgap: 0.3, pattern: 'independent' },
       shapes: [],
-      violingap: 0,
     };
 
     return beautifyLayout(traces, innerLayout);


### PR DESCRIPTION
Fixes typing error introduced by new plotly version 

### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Changing Layout type -> Partial<Layout>

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
