### PR TITLE
fix: remove range id mapping in `rangeOf` in DB view filter

### DIFF
--- a/tdp_core/sql_filter.py
+++ b/tdp_core/sql_filter.py
@@ -2,8 +2,6 @@ import logging
 
 from werkzeug.datastructures import MultiDict
 
-from . import manager
-
 _log = logging.getLogger(__name__)
 
 

--- a/tdp_core/sql_filter.py
+++ b/tdp_core/sql_filter.py
@@ -33,30 +33,6 @@ def _replace_named_sets_in_ids(v):
     return list(union)
 
 
-def _replace_range_in_ids(v, id_type, target_id_type):
-    union = set()
-
-    def add_range(r):
-        # convert named sets to the primary ids
-        ids = r
-        if id_type != target_id_type:
-            # need to map the ids
-            mapped_ids = manager.id_mapping(id_type, target_id_type, ids)
-            for id in mapped_ids:
-                if id is not None and len(id) > 0:
-                    union.add(id[0])  # just the first one for now
-        else:
-            for id in ids:
-                union.add(id)
-
-    if isinstance(v, list):
-        for vi in v:
-            add_range(vi)
-    else:
-        add_range(v)
-    return list(union)
-
-
 def filter_logic(view, args):
     """
     parses the request arguments for filter
@@ -87,9 +63,8 @@ def filter_logic(view, args):
         if k.startswith("rangeOf"):
             del where_clause[k]  # delete value
             id_type_and_key = k[7:]
-            id_type = id_type_and_key[: id_type_and_key.index("4")]
             real_key = id_type_and_key[id_type_and_key.index("4") + 1 :]  # remove the range4 part
-            ids = _replace_range_in_ids(v, id_type, view.idtype)
+            ids = v
             if real_key not in where_clause:
                 where_clause[real_key] = ids
             else:


### PR DESCRIPTION
Closes Caleydo/tdp_bi_bioinfodb#1416


### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Remove id mapping in `rangeOf` filter of DB views (used by Ordino)

### Screenshots

Before this PR

![grafik](https://user-images.githubusercontent.com/5851088/206147093-d00570f8-a3aa-42e3-a59d-a03137be43df.png)


After this PR

![grafik](https://user-images.githubusercontent.com/5851088/206156886-4a63a257-81df-43e8-a045-e44adf33c58f.png)


### Additional notes for the reviewer(s)

@oltionchampari  Please test this change in Ordino also with aggregated scores and using a Gene list and adding Cell Line scores. Thanks.


---
[ordino-gene-score-filter-post-request-fixed.webm](https://user-images.githubusercontent.com/5851088/206156802-ddd9003c-ebcd-4278-bcb3-d5c3210d5125.webm)

Thanks for creating this pull request 🤗
