### PR TITLE
fix: show notification when score loading fails

### DIFF
--- a/src/lineup/ARankingView.ts
+++ b/src/lineup/ARankingView.ts
@@ -519,7 +519,7 @@ export abstract class ARankingView extends AView {
     const columnPromise: Promise<Column> = new Promise((resolve) => {
       columnResolve = resolve;
     });
-    const data: Promise<IScoreRow<any>[]> = new Promise((resolve) => {
+    const data: Promise<IScoreRow<any>[]> = new Promise((resolve, reject) => {
       (async () => {
         // Wait for the column to be initialized
         const col = await columnPromise;
@@ -592,7 +592,7 @@ export abstract class ARankingView extends AView {
               }
               continue;
             } else {
-              throw e;
+              reject(e);
             }
           }
         }

--- a/src/lineup/ARankingView.ts
+++ b/src/lineup/ARankingView.ts
@@ -593,6 +593,7 @@ export abstract class ARankingView extends AView {
               continue;
             } else {
               reject(e);
+              done = true;
             }
           }
         }


### PR DESCRIPTION
Closes  https://github.com/Caleydo/tdp_bi_bioinfodb/issues/1388

### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [x] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Reject the parent promise when the `score.compute` promise is rejected
- Throwing the error does not propagate the promise above so the `data.catch` never gets called, i.e., the notification is never shown
- The code should not affect the authorization code above

### Screenshots

![gr](https://user-images.githubusercontent.com/51322092/216088237-238974e4-0efc-4736-9a96-0767642e580a.gif)


### Additional notes for the reviewer(s)

#### To test 

Change    ` statement_timeout: str = "'5min'"` to  ` statement_timeout: str = "'1s'"`  in
 ```
 class TDPPublicDBSettings(BaseModel):
    dburl: str = "postgresql://publicdb:publicdb@publicdb:5432/publicdb"
    statement_timeout: str = "'5min'"
    statement_timeout_query: str = "set statement_timeout to {}"
    engine: dict = {"pool_pre_ping": True}
```
 
