### PR TITLE
Adding scroll zoom vis option

### DIFF
--- a/src/vis/Vis.tsx
+++ b/src/vis/Vis.tsx
@@ -41,6 +41,7 @@ export function EagerVis({
   showSidebar: internalShowSidebar,
   setShowSidebar: internalSetShowSidebar,
   showSidebarDefault = false,
+  scrollZoom = true,
 }: {
   /**
    * Required data columns which are displayed.
@@ -74,6 +75,7 @@ export function EagerVis({
   showSidebar?: boolean;
   setShowSidebar?(show: boolean): void;
   showSidebarDefault?: boolean;
+  scrollZoom?: boolean;
 }) {
   const [showSidebar, setShowSidebar] = useUncontrolled<boolean>({
     value: internalShowSidebar,
@@ -228,6 +230,7 @@ export function EagerVis({
           showSidebar={showSidebar}
           showCloseButton={showCloseButton}
           closeButtonCallback={closeCallback}
+          scrollZoom={scrollZoom}
           {...commonProps}
         />
       ) : null}

--- a/src/vis/scatter/ScatterVis.tsx
+++ b/src/vis/scatter/ScatterVis.tsx
@@ -41,6 +41,7 @@ export function ScatterVis({
   showCloseButton = false,
   closeButtonCallback = () => null,
   scales,
+  scrollZoom,
 }: {
   config: IScatterConfig;
   optionsConfig?: {
@@ -76,6 +77,7 @@ export function ScatterVis({
   setShowSidebar?(show: boolean): void;
   enableSidebar?: boolean;
   showCloseButton?: boolean;
+  scrollZoom?: boolean;
 }) {
   const id = React.useMemo(() => uniqueId('ScatterVis'), []);
   const plotlyDivRef = React.useRef(null);
@@ -201,7 +203,7 @@ export function ScatterVis({
           divId={`plotlyDiv${id}`}
           data={plotlyData}
           layout={layout}
-          config={{ responsive: true, displayModeBar: false, scrollZoom: true }}
+          config={{ responsive: true, displayModeBar: false, scrollZoom }}
           useResizeHandler
           style={{ width: '100%', height: '100%' }}
           onClick={(event) => {
@@ -219,7 +221,7 @@ export function ScatterVis({
       );
     }
     return null;
-  }, [id, plotsWithSelectedPoints, layout, selectedMap, selectionCallback, selectedList, traces?.plots, plotlyData]);
+  }, [id, plotsWithSelectedPoints, layout, selectedMap, selectionCallback, selectedList, traces?.plots, plotlyData, scrollZoom]);
 
   return (
     <Container


### PR DESCRIPTION
For https://github.com/datavisyn/aelixir/issues/382

### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Adding top level option for scroll zoom on the scatterplot. Only affects the scatterplot, as the hexbin plot apparently does not have scroll zooming unless you are on the zoom option. Probably something to change in the future, as zooming should be possible in hexbin as well.

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
