### PR TITLE
feat: extend logging in db.py and dbview.py

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 black~=22.12.0
-pyright==1.1.285
+pyright==1.1.308
 pytest-runner~=6.0.0
 pytest~=7.2.0
 ruff==0.0.218

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 black~=22.12.0
-pyright~=1.1.285
+pyright==1.1.285
 pytest-runner~=6.0.0
 pytest~=7.2.0
 ruff==0.0.218

--- a/tdp_core/db.py
+++ b/tdp_core/db.py
@@ -109,6 +109,7 @@ class WrappedSession:
         """
         self._engine = engine
         import uuid
+
         self._name = uuid.uuid4()
         _log.debug("%s - engine status before: %s", self._name, engine.pool.status())
         _log.debug("%s - creating session", self._name)
@@ -133,11 +134,10 @@ class WrappedSession:
         try:
             return self._session.execute(parsed, kwargs)
         except OperationalError as error:
-            _log.error('OperationalError: %s', error)
+            _log.error("OperationalError: %s", error)
             abort(408, error)
         except SQLAlchemyError as error:
-            _log.error('SQLAlchemyError: %s', error)
-            
+            _log.error("SQLAlchemyError: %s", error)
 
     def run(self, sql, **kwargs):
         """
@@ -149,8 +149,8 @@ class WrappedSession:
         _log.debug("%s - run sql statement: %s", self._name, sql)
         result = self.execute(sql, **kwargs)
         _log.debug("%s - ran sql statement: %s", self._name, sql)
-        columns = result.keys()
-        return [{c: r[c] for c in columns} for r in result]
+        columns = result.keys()  # type: ignore
+        return [{c: r[c] for c in columns} for r in result]  # type: ignore
 
     def __call__(self, sql, **kwargs):
         return self.run(sql, **kwargs)
@@ -514,7 +514,7 @@ def derive_columns(table_name, engine, columns=None):
                 template = "min({col}) as {col}_min, max({col}) as {col}_max"
                 minmax = ", ".join(template.format(col=col) for col in number_columns)
                 _log.debug("%s - DERIVE COLUMNS number columns before run", sess._name)
-                row = next(iter(sess.execute("""SELECT {minmax} FROM {table}""".format(table=table_name, minmax=minmax))))
+                row = next(iter(sess.execute("""SELECT {minmax} FROM {table}""".format(table=table_name, minmax=minmax))))  # type: ignore
                 _log.debug("%s - DERIVE COLUMNS number columns after run", sess._name)
                 for num_col in number_columns:
                     columns[num_col]["min"] = row[num_col + "_min"]
@@ -527,7 +527,7 @@ def derive_columns(table_name, engine, columns=None):
                 _log.debug("%s - DERIVE COLUMNS categorical columns before run: %s, %s", sess._name, table_name, col)
                 cats = sess.execute(template.format(col=col, table=table_name))
                 _log.debug("%s - DERIVE COLUMNS categorical columns after run: %s, %s", sess._name, table_name, col)
-                categories = [str(r["cat"]) for r in cats if r["cat"] is not None]
+                categories = [str(r["cat"]) for r in cats if r["cat"] is not None]  # type: ignore
                 if columns[col]["type"] == "set":
                     separator = getattr(columns[col], "separator", ";")
                     separated_categories = [category.split(separator) for category in categories]

--- a/tdp_core/db.py
+++ b/tdp_core/db.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any
 
 from flask import abort
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.orm import Session
 from visyn_core import manager
 from werkzeug.datastructures import MultiDict
@@ -107,9 +107,17 @@ class WrappedSession:
         session wrapper of sql alchemy with auto cleanup
         :param engine:
         """
-        _log.info("creating session")
+        self._engine = engine
+        import uuid
+        self._name = uuid.uuid4()
+        _log.debug("%s - engine status before: %s", self._name, engine.pool.status())
+        _log.debug("%s - creating session", self._name)
+        # add connection count and session count with SQLALCHEMY_POOL_SIZE and SQLALCHEMY_MAX_OVERFLOW
+        # https://stackoverflow.com/questions/34775501/how-could-i-check-the-number-of-active-sqlalchemy-connections-in-a-pool-at-any-g
         self._session: Session = manager.db.create_session(engine)
+        _log.debug("%s - session created", self._name)
         self._supports_array_parameter = _supports_sql_parameters(engine.name)
+        _log.debug("%s - supports array parameter: %s", self._name, self._supports_array_parameter)
 
     def execute(self, sql, **kwargs):
         """
@@ -118,12 +126,18 @@ class WrappedSession:
         :param kwargs: additional args to replace
         :return: the session result
         """
+        _log.debug("%s - replace array parameter in sql query: %s", self._name, sql)
         parsed = to_query(sql, self._supports_array_parameter, kwargs)
-        _log.info("%s (%s)", parsed, kwargs)
+        _log.debug("%s - execute the given query with the given args: %s", self._name, sql)
+        _log.debug("%s (%s)", parsed, kwargs)
         try:
             return self._session.execute(parsed, kwargs)
         except OperationalError as error:
+            _log.error('OperationalError: %s', error)
             abort(408, error)
+        except SQLAlchemyError as error:
+            _log.error('SQLAlchemyError: %s', error)
+            
 
     def run(self, sql, **kwargs):
         """
@@ -132,7 +146,9 @@ class WrappedSession:
         :param kwargs: args for this query
         :return: list of dicts
         """
+        _log.debug("%s - run sql statement: %s", self._name, sql)
         result = self.execute(sql, **kwargs)
+        _log.debug("%s - ran sql statement: %s", self._name, sql)
         columns = result.keys()
         return [{c: r[c] for c in columns} for r in result]
 
@@ -153,9 +169,11 @@ class WrappedSession:
 
     def _destroy(self):
         if self._session:
-            _log.info("removing session again")
+            _log.debug("%s - removing session", self._name)
             self._session.close()
             self._session = None  # type: ignore
+            _log.debug("%s - removed session", self._name)
+            _log.debug("%s - engine status after destroy: %s", self._name, self._engine.pool.status())
 
     def __del__(self):
         self._destroy()
@@ -342,14 +360,18 @@ def get_data(
     query = view.query
 
     if callable(query):
+        _log.debug("GET DATA with callback variant")
         # callback variant
         return query(engine, arguments, filters), view
 
     with session(engine) as sess:
+        _log.debug("%s - GET DATA with session", sess._name)
         if config.statement_timeout and config.statement_timeout_query:
-            _log.info("set statement_timeout to {}".format(config.statement_timeout))
+            _log.debug("set statement_timeout to {}".format(config.statement_timeout))
             sess.execute(config.statement_timeout_query.format(config.statement_timeout))
+        _log.debug("%s - GET DATA before run", sess._name)
         r = sess.run(query.format(**replace), **kwargs)
+        _log.debug("%s - GET DATA after run", sess._name)
     return r, view
 
 
@@ -434,10 +456,13 @@ def get_count(database, view_name, args):
         return count_query(engine, processed_args, where_clause)
 
     with session(engine) as sess:
+        _log.debug("%s - GET COUNT with session", sess._name)
         if config.statement_timeout and config.statement_timeout_query:
-            _log.info("set statement_timeout to {}".format(config.statement_timeout))
+            _log.debug("set statement_timeout to {}".format(config.statement_timeout))
             sess.execute(config.statement_timeout_query.format(config.statement_timeout))
+        _log.debug("%s - GET COUNT before run", sess._name)
         r = sess.run(count_query.format(**replace), **kwargs)
+        _log.debug("%s - GET COUNT after run", sess._name)
     if r:
         return r[0]["count"]
     return 0
@@ -483,11 +508,14 @@ def derive_columns(table_name, engine, columns=None):
         k for k, col in columns.items() if (col["type"] == "categorical" or col["type"] == "set") and "categories" not in col
     ]
     if number_columns or categorical_columns:
-        with session(engine) as s:
+        with session(engine) as sess:
+            _log.debug("%s - DERIVE COLUMNS with session", sess._name)
             if number_columns:
                 template = "min({col}) as {col}_min, max({col}) as {col}_max"
                 minmax = ", ".join(template.format(col=col) for col in number_columns)
-                row = next(iter(s.execute("""SELECT {minmax} FROM {table}""".format(table=table_name, minmax=minmax))))
+                _log.debug("%s - DERIVE COLUMNS number columns before run", sess._name)
+                row = next(iter(sess.execute("""SELECT {minmax} FROM {table}""".format(table=table_name, minmax=minmax))))
+                _log.debug("%s - DERIVE COLUMNS number columns after run", sess._name)
                 for num_col in number_columns:
                     columns[num_col]["min"] = row[num_col + "_min"]
                     columns[num_col]["max"] = row[num_col + "_max"]
@@ -496,7 +524,9 @@ def derive_columns(table_name, engine, columns=None):
                 if _differentiates_empty_string_and_null(engine.name):
                     template += """ AND {col} <> ''"""
                 template += """ ORDER BY {col} ASC"""
-                cats = s.execute(template.format(col=col, table=table_name))
+                _log.debug("%s - DERIVE COLUMNS categorical columns before run: %s, %s", sess._name, table_name, col)
+                cats = sess.execute(template.format(col=col, table=table_name))
+                _log.debug("%s - DERIVE COLUMNS categorical columns after run: %s, %s", sess._name, table_name, col)
                 categories = [str(r["cat"]) for r in cats if r["cat"] is not None]
                 if columns[col]["type"] == "set":
                     separator = getattr(columns[col], "separator", ";")
@@ -505,12 +535,13 @@ def derive_columns(table_name, engine, columns=None):
                     categories = list({category for sublist in separated_categories for category in sublist})
                     categories.sort()  # sort list to avoid random order with each run
                 columns[col]["categories"] = categories
+            _log.debug("%s - DERIVE COLUMNS done", sess._name)
 
     return columns
 
 
 def _fill_up_columns(view, engine):
-    _log.info("fill up view")
+    _log.debug("fill up view %s", view)
     # update the real object
     view.columns = derive_columns(view.table, engine, view.columns)
     view.columns_filled_up = True

--- a/tdp_core/dbview.py
+++ b/tdp_core/dbview.py
@@ -607,6 +607,7 @@ class DBConnector:
         :param agg_score: optional specify how aggregation should be handled
         :param mappings: optional database mappings
         """
+        _log.debug("create db connector")
         self.agg_score = agg_score or default_agg_score
         self.views = views or {}
         self.dburl: str = None  # type: ignore
@@ -625,7 +626,9 @@ class DBConnector:
             "pool_pre_ping": True,
         }
         engine_options.update(config.get("engine", {}))
+        _log.debug("db connector: create engine with options %s", engine_options)
         return sqlalchemy.create_engine(self.dburl, **engine_options)
 
     def create_sessionmaker(self, engine) -> sessionmaker:
+        _log.debug("db connector: create_sessionmaker")
         return sessionmaker(bind=engine)

--- a/tdp_core/mapping_table.py
+++ b/tdp_core/mapping_table.py
@@ -29,7 +29,7 @@ class SQLMappingTable:
             mapped = session.execute(self._query, ids=ids)
 
             # handle multi mappings
-            data = sorted(mapped, key=lambda x: x["f"])
+            data = sorted(mapped, key=lambda x: x["f"])  # type: ignore
             grouped = {k: [r["t"] for r in g] for k, g in itertools.groupby(data, lambda x: x["f"])}
             # Return according to the given ids to ensure that we are preserving the order correctly
             return [grouped.get(id, []) for id in ids]


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Add further logging to db.py and dbview.py

Enable the debug logs via env variable `VISYN_CORE__LOG_LEVEL=DEBUG` or in `visyn_core.log_level` the config.json:

```json
{
    "visyn_core": {
        "log_level": "DEBUG"
    }
}
```


### Screenshots

Example:

```
ordino_public-api-1          | DEBUG:    2023-07-24 12:29:57 |                    tdp_core.db | a8c85c7d-2e97-4e91-8dd7-31ed5628cb39 - engine status before: Pool size: 30  Connections in pool: 1 Current Overflow: -27 Current Checked out connections: 2
ordino_public-api-1          | DEBUG:    2023-07-24 12:29:57 |                    tdp_core.db | a8c85c7d-2e97-4e91-8dd7-31ed5628cb39 - creating session
ordino_public-api-1          | DEBUG:    2023-07-24 12:29:57 |                    tdp_core.db | a8c85c7d-2e97-4e91-8dd7-31ed5628cb39 - session created
ordino_public-api-1          | DEBUG:    2023-07-24 12:29:57 |                    tdp_core.db | a8c85c7d-2e97-4e91-8dd7-31ed5628cb39 - supports array parameter: True
ordino_public-api-1          | DEBUG:    2023-07-24 12:29:57 |                    tdp_core.db | a8c85c7d-2e97-4e91-8dd7-31ed5628cb39 - GET DATA with session
ordino_public-api-1          | DEBUG:    2023-07-24 12:29:57 |                    tdp_core.db | set statement_timeout to '5min'
ordino_public-api-1          | DEBUG:    2023-07-24 12:29:57 |                    tdp_core.db | a8c85c7d-2e97-4e91-8dd7-31ed5628cb39 - replace array parameter in sql query: set statement_timeout to '5min'
ordino_public-api-1          | DEBUG:    2023-07-24 12:29:57 |                    tdp_core.db | a8c85c7d-2e97-4e91-8dd7-31ed5628cb39 - execute the given query with the given args: set statement_timeout to '5min'
ordino_public-api-1          | DEBUG:    2023-07-24 12:29:57 |                    tdp_core.db | set statement_timeout to '5min' ({})
ordino_public-api-1          | DEBUG:    2023-07-24 12:29:57 |                    tdp_core.db | d6ff6071-f63c-4921-9567-709fcff69e00 - ran sql statement: 
ordino_public-api-1          |   SELECT panel as id, paneldescription as description, species
ordino_public-api-1          |   FROM cellline.tdp_panel ORDER BY panel ASC
ordino_public-api-1          | DEBUG:    2023-07-24 12:29:57 |                    tdp_core.db | d6ff6071-f63c-4921-9567-709fcff69e00 - GET DATA after run
ordino_public-api-1          | DEBUG:    2023-07-24 12:29:57 |                    tdp_core.db | d6ff6071-f63c-4921-9567-709fcff69e00 - removing session
ordino_public-api-1          | DEBUG:    2023-07-24 12:29:57 |                    tdp_core.db | d6ff6071-f63c-4921-9567-709fcff69e00 - removed session
```


### Additional notes for the reviewer(s)

@puehringer I added my logs with the log level DEBUG. Is it ok like this or should I add a separate flag to the tdp_core settings to enable the very specific case of logging db.py and dbview.py?

---
Thanks for creating this pull request 🤗
